### PR TITLE
Parser for benchmark scheduling instance data files

### DIFF
--- a/.github/workflows/api-webpage-sitemap.yml
+++ b/.github/workflows/api-webpage-sitemap.yml
@@ -26,7 +26,7 @@ jobs:
         echo "url-count = ${{ steps.sitemap.outputs.url-count }}"
         echo "excluded-count = ${{ steps.sitemap.outputs.excluded-count }}"
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3.3.0
+      uses: peter-evans/create-pull-request@v3.4.0
       with:
         title: "Automated sitemap update"
         body: > 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2020-09-17
 
 ### Added
+* Parser for benchmark scheduling instance data files for single machine scheduling problems with weights, duedates, and sequence-dependent setup times.
 
 ### Changed
 * Revised README to include instructions for importing from Maven Central

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2020-09-16
+## [Unreleased] - 2020-09-17
 
 ### Added
 
 ### Changed
+* Revised README to include instructions for importing from Maven Central
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -76,23 +76,32 @@ will be in the exbin directory.  See [examples/README.md](examples/README.md) fo
 
 ## Versioning Scheme
 
-Chips-n-Salsa uses [Semantic Versioning](https://semver.org/) with version numbers of the form: MAJOR.MINOR.PATCH,
-where differences in MAJOR correspond to incompatible API changes, differences in MINOR correspond to introduction
-of backwards compatible new functionality, and PATCH corresponds to backwards compatible bug fixes. 
+Chips-n-Salsa uses [Semantic Versioning](https://semver.org/) with 
+version numbers of the form: MAJOR.MINOR.PATCH, where differences 
+in MAJOR correspond to incompatible API changes, differences in MINOR 
+correspond to introduction of backwards compatible new functionality, 
+and PATCH corresponds to backwards compatible bug fixes. 
 
-## Importing the Library Into a Project Using Maven
+## Importing the Library from Maven Central
 
-__Step 1__: Add this to the dependencies section of your pom.xml, replacing the version number with the version you want to use.
+Add this to the dependencies section of your pom.xml, replacing 
+the version number with the version that you want to use (note that the 
+library has been available in Maven Central since version 2.0.0).
 
 ```XML
 <dependency>
   <groupId>org.cicirello</groupId>
   <artifactId>chips-n-salsa</artifactId>
-  <version>1.1.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
-__Step 2__: Add this to the repositories section of your pom.xml.
+## Importing the Library from GitHub Packages
+
+If you'd prefer to import from GitHub Packages, rather than Maven Central, or
+if you need a version that is unavailable in Maven Central (versions prior to 2.0.0),
+then: (1) add the dependency as indicated in previous section above, and (2) add 
+the following to the repositories section of your pom.xml:
 
 ```XML
 <repository>
@@ -104,16 +113,13 @@ __Step 2__: Add this to the repositories section of your pom.xml.
 </repository>
 ```
 
-__Step 3__: Run this via the command line.
-
-```
-$ mvn install
-```
-
 ## License
 
 The Chips-n-Salsa library is licensed under the [GNU General Public License 3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).
 
 ## Contribute
 
-If you would like to contribute to Chips-n-Salsa in any way, such as reporting bugs, suggesting new functionality, or code contributions such as bug fixes or implementations of new functionality, then start by reading the [contribution guidelines](CONTRIBUTING.md).
+If you would like to contribute to Chips-n-Salsa in any way, such 
+as reporting bugs, suggesting new functionality, or code contributions 
+such as bug fixes or implementations of new functionality, then start 
+by reading the [contribution guidelines](CONTRIBUTING.md).

--- a/docs/api/index-all.html
+++ b/docs/api/index-all.html
@@ -3227,6 +3227,16 @@
 <dd>&nbsp;</dd>
 <dt><span class="memberNameLink"><a href="org/cicirello/search/ss/PartialPermutation.html#toComplete--">toComplete()</a></span> - Method in class org.cicirello.search.ss.<a href="org/cicirello/search/ss/PartialPermutation.html" title="class in org.cicirello.search.ss">PartialPermutation</a></dt>
 <dd>&nbsp;</dd>
+<dt><span class="memberNameLink"><a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#toFile-java.lang.String-">toFile(String)</a></span> - Method in class org.cicirello.search.problems.scheduling.<a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html" title="class in org.cicirello.search.problems.scheduling">WeightedStaticSchedulingWithSetups</a></dt>
+<dd>
+<div class="block">Outputs a description of the instance data in the format
+ based on that described in:</div>
+</dd>
+<dt><span class="memberNameLink"><a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#toFile-java.lang.String-int-">toFile(String, int)</a></span> - Method in class org.cicirello.search.problems.scheduling.<a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html" title="class in org.cicirello.search.problems.scheduling">WeightedStaticSchedulingWithSetups</a></dt>
+<dd>
+<div class="block">Outputs a description of the instance data in the format
+ based on that described in:</div>
+</dd>
 <dt><span class="memberNameLink"><a href="org/cicirello/search/representations/BitVector.html#toString--">toString()</a></span> - Method in class org.cicirello.search.representations.<a href="org/cicirello/search/representations/BitVector.html" title="class in org.cicirello.search.representations">BitVector</a></dt>
 <dd>&nbsp;</dd>
 <dt><a href="org/cicirello/search/TrackableSearch.html" title="interface in org.cicirello.search"><span class="typeNameLink">TrackableSearch</span></a>&lt;<a href="org/cicirello/search/TrackableSearch.html" title="type parameter in TrackableSearch">T</a> extends <a href="https://jpt.cicirello.org/api/org/cicirello/util/Copyable.html?is-external=true" title="class or interface in org.cicirello.util">Copyable</a>&lt;<a href="org/cicirello/search/TrackableSearch.html" title="type parameter in TrackableSearch">T</a>&gt;&gt; - Interface in <a href="org/cicirello/search/package-summary.html">org.cicirello.search</a></dt>
@@ -3624,6 +3634,12 @@
 <dt><span class="memberNameLink"><a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#WeightedStaticSchedulingWithSetups-int-double-double-double-">WeightedStaticSchedulingWithSetups(int, double, double, double)</a></span> - Constructor for class org.cicirello.search.problems.scheduling.<a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html" title="class in org.cicirello.search.problems.scheduling">WeightedStaticSchedulingWithSetups</a></dt>
 <dd>
 <div class="block">Generates random single machine scheduling problem instances.</div>
+</dd>
+<dt><span class="memberNameLink"><a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#WeightedStaticSchedulingWithSetups-java.lang.String-">WeightedStaticSchedulingWithSetups(String)</a></span> - Constructor for class org.cicirello.search.problems.scheduling.<a href="org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html" title="class in org.cicirello.search.problems.scheduling">WeightedStaticSchedulingWithSetups</a></dt>
+<dd>
+<div class="block">Constructs a single machine scheduling problem instance by parsing
+ an instance data file that follows the format specified in the following
+ paper, with instances available at the following link:</div>
 </dd>
 <dt><a href="org/cicirello/search/problems/scheduling/WeightedTardiness.html" title="class in org.cicirello.search.problems.scheduling"><span class="typeNameLink">WeightedTardiness</span></a> - Class in <a href="org/cicirello/search/problems/scheduling/package-summary.html">org.cicirello.search.problems.scheduling</a></dt>
 <dd>

--- a/docs/api/org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html
+++ b/docs/api/org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html
@@ -17,7 +17,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10,"i10":10,"i11":10};
 var tabs = {65535:["t0","All Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -271,6 +271,13 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <div class="block">Generates random single machine scheduling problem instances.</div>
 </td>
 </tr>
+<tr class="altColor">
+<td class="colOne"><code><span class="memberNameLink"><a href="../../../../../org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#WeightedStaticSchedulingWithSetups-java.lang.String-">WeightedStaticSchedulingWithSetups</a></span>(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename)</code>
+<div class="block">Constructs a single machine scheduling problem instance by parsing
+ an instance data file that follows the format specified in the following
+ paper, with instances available at the following link:</div>
+</td>
+</tr>
 </table>
 </li>
 </ul>
@@ -352,6 +359,21 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <td class="colFirst"><code>int</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../../org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#numberOfJobs--">numberOfJobs</a></span>()</code>
 <div class="block">Gets the number of jobs of this scheduling problem instance.</div>
+</td>
+</tr>
+<tr id="i10" class="altColor">
+<td class="colFirst"><code>void</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../../org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#toFile-java.lang.String-">toFile</a></span>(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename)</code>
+<div class="block">Outputs a description of the instance data in the format
+ based on that described in:</div>
+</td>
+</tr>
+<tr id="i11" class="rowColor">
+<td class="colFirst"><code>void</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../../org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html#toFile-java.lang.String-int-">toFile</a></span>(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename,
+      int&nbsp;instanceNumber)</code>
+<div class="block">Outputs a description of the instance data in the format
+ based on that described in:</div>
 </td>
 </tr>
 </table>
@@ -511,7 +533,7 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <a name="WeightedStaticSchedulingWithSetups-int-double-double-double-">
 <!--   -->
 </a>
-<ul class="blockListLast">
+<ul class="blockList">
 <li class="blockList">
 <h4>WeightedStaticSchedulingWithSetups</h4>
 <pre>public&nbsp;WeightedStaticSchedulingWithSetups(int&nbsp;n,
@@ -533,6 +555,41 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <dt><span class="throwsLabel">Throws:</span></dt>
 <dd><code><a href="https://docs.oracle.com/javase/8/docs/api/java/lang/IllegalArgumentException.html?is-external=true" title="class or interface in java.lang">IllegalArgumentException</a></code> - if n is not positive, or if any of tau, eta, or r are not in 
  the interval [0.0, 1.0].</dd>
+</dl>
+</li>
+</ul>
+<a name="WeightedStaticSchedulingWithSetups-java.lang.String-">
+<!--   -->
+</a>
+<ul class="blockListLast">
+<li class="blockList">
+<h4>WeightedStaticSchedulingWithSetups</h4>
+<pre>public&nbsp;WeightedStaticSchedulingWithSetups(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename)
+                                   throws <a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></pre>
+<div class="block"><p>Constructs a single machine scheduling problem instance by parsing
+ an instance data file that follows the format specified in the following
+ paper, with instances available at the following link:</p>
+ <ul>
+ <li>Vincent A. Cicirello. 
+ <a href="https://www.cicirello.org/publications/cicirello2003cmu.html">Weighted 
+ Tardiness Scheduling with Sequence-Dependent Setups: A Benchmark Library</a>.
+ Technical Report, Intelligent Coordination and Logistics Laboratory, Robotics 
+ Institute, Carnegie Mellon University, Pittsburgh, PA, February 2003.</li>
+ <li>Vincent A. Cicirello.
+ <a href="http://dx.doi.org/10.7910/DVN/VHA0VQ">Weighted 
+ Tardiness Scheduling with Sequence-Dependent Setups: A Benchmark Library</a>.
+ Harvard Dataverse, doi:10.7910/DVN/VHA0VQ, June 2016.</li>
+ </ul>
+ <p>Note that the paper above describes a weighted tardiness scheduling
+ problem, but the instance data (process and setup times, weights, duedates)
+ can also be used with other scheduling objective functions</p></div>
+<dl>
+<dt><span class="paramLabel">Parameters:</span></dt>
+<dd><code>filename</code> - The name of the data instance file, with path.</dd>
+<dt><span class="throwsLabel">Throws:</span></dt>
+<dd><code><a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></code> - if the named file does not exist, is a 
+ directory rather than a regular file, or for some other reason cannot 
+ be opened for reading</dd>
 </dl>
 </li>
 </ul>
@@ -751,7 +808,7 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <a name="hasSetupTimes--">
 <!--   -->
 </a>
-<ul class="blockListLast">
+<ul class="blockList">
 <li class="blockList">
 <h4>hasSetupTimes</h4>
 <pre>public&nbsp;boolean&nbsp;hasSetupTimes()</pre>
@@ -762,6 +819,71 @@ implements <a href="../../../../../org/cicirello/search/problems/scheduling/Sing
 <dd><code><a href="../../../../../org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.html#hasSetupTimes--">hasSetupTimes</a></code>&nbsp;in interface&nbsp;<code><a href="../../../../../org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.html" title="interface in org.cicirello.search.problems.scheduling">SingleMachineSchedulingProblemData</a></code></dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>true iff setup times are present.</dd>
+</dl>
+</li>
+</ul>
+<a name="toFile-java.lang.String-">
+<!--   -->
+</a>
+<ul class="blockList">
+<li class="blockList">
+<h4>toFile</h4>
+<pre>public&nbsp;void&nbsp;toFile(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename)
+            throws <a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></pre>
+<div class="block"><p>Outputs a description of the instance data in the format
+ based on that described in:</p>
+ <p>Vincent A. Cicirello. 
+ <a href="https://www.cicirello.org/publications/cicirello2003cmu.html">Weighted 
+ Tardiness Scheduling with Sequence-Dependent Setups: A Benchmark Library</a>.
+ Technical Report, Intelligent Coordination and Logistics Laboratory, Robotics 
+ Institute, Carnegie Mellon University, Pittsburgh, PA, February 2003.</p>
+ <p>The data as output by this method varies from that format in that it
+ does not output the "Generator Parameters" section.  Instead, it has the
+ "Begin Generator Parameters" and the "End Generator Parameters" block markers,
+ but an empty block.  The constructor of this class that takes an instance data
+ file as input can correctly parse both the original and this modified format.</p>
+ <p>This method will output a -1 for the problem instance number. If you wish
+ to have meaningful problem instance numbers, use the version of the method that
+ includes a parameter for this.</p></div>
+<dl>
+<dt><span class="paramLabel">Parameters:</span></dt>
+<dd><code>filename</code> - The name of a file for the output.</dd>
+<dt><span class="throwsLabel">Throws:</span></dt>
+<dd><code><a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></code> - If the given string does not denote 
+ an existing, writable regular file and a new regular file of that name 
+ cannot be created, or if some other error occurs while opening or creating the file</dd>
+</dl>
+</li>
+</ul>
+<a name="toFile-java.lang.String-int-">
+<!--   -->
+</a>
+<ul class="blockListLast">
+<li class="blockList">
+<h4>toFile</h4>
+<pre>public&nbsp;void&nbsp;toFile(<a href="https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true" title="class or interface in java.lang">String</a>&nbsp;filename,
+                   int&nbsp;instanceNumber)
+            throws <a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></pre>
+<div class="block"><p>Outputs a description of the instance data in the format
+ based on that described in:</p>
+ <p>Vincent A. Cicirello. 
+ <a href="https://www.cicirello.org/publications/cicirello2003cmu.html">Weighted 
+ Tardiness Scheduling with Sequence-Dependent Setups: A Benchmark Library</a>.
+ Technical Report, Intelligent Coordination and Logistics Laboratory, Robotics 
+ Institute, Carnegie Mellon University, Pittsburgh, PA, February 2003.</p>
+ <p>The data as output by this method varies from that format in that it
+ does not output the "Generator Parameters" section.  Instead, it has the
+ "Begin Generator Parameters" and the "End Generator Parameters" block markers,
+ but an empty block.  The constructor of this class that takes an instance data
+ file as input can correctly parse both the original and this modified format.</p></div>
+<dl>
+<dt><span class="paramLabel">Parameters:</span></dt>
+<dd><code>filename</code> - The name of a file for the output.</dd>
+<dd><code>instanceNumber</code> - An id for the problem instance.</dd>
+<dt><span class="throwsLabel">Throws:</span></dt>
+<dd><code><a href="https://docs.oracle.com/javase/8/docs/api/java/io/FileNotFoundException.html?is-external=true" title="class or interface in java.io">FileNotFoundException</a></code> - If the given string does not denote 
+ an existing, writable regular file and a new regular file of that name 
+ cannot be created, or if some other error occurs while opening or creating the file</dd>
 </dl>
 </li>
 </ul>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -30,7 +30,7 @@
 </url>
 <url>
 <loc>https://chips-n-salsa.cicirello.org/api/index-all.html</loc>
-<lastmod>2020-09-10T13:30:39-04:00</lastmod>
+<lastmod>2020-09-17T14:07:37-04:00</lastmod>
 </url>
 <url>
 <loc>https://chips-n-salsa.cicirello.org/api/overview-frame.html</loc>
@@ -754,7 +754,7 @@
 </url>
 <url>
 <loc>https://chips-n-salsa.cicirello.org/api/org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetups.html</loc>
-<lastmod>2020-08-06T10:54:27-04:00</lastmod>
+<lastmod>2020-09-17T14:07:37-04:00</lastmod>
 </url>
 <url>
 <loc>https://chips-n-salsa.cicirello.org/api/org/cicirello/search/problems/scheduling/WeightedTardiness.html</loc>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>org.cicirello</groupId>
 			<artifactId>jpt</artifactId>
-			<version>2.1.2</version>
+			<version>2.1.3</version>
 		</dependency>
 	</dependencies>
   

--- a/tests/org/cicirello/search/problems/scheduling/WeightedStaticSetupsTests.java
+++ b/tests/org/cicirello/search/problems/scheduling/WeightedStaticSetupsTests.java
@@ -23,11 +23,74 @@ package org.cicirello.search.problems.scheduling;
 import org.junit.*;
 import static org.junit.Assert.*;
 import org.cicirello.permutations.Permutation;
+import java.io.StringWriter;
+import java.io.StringReader;
+import java.io.PrintWriter;
+import java.util.Scanner;
 
 /**
  * JUnit tests for the WeightedStaticSchedulingWithSetups class.
  */
 public class WeightedStaticSetupsTests {
+	
+	@Test
+	public void testReadWriteInstanceData() {
+		double[] tau = {0.0, 0.5, 1.0};
+		double[] r = {0.0, 0.5, 1.0};
+		double[] eta = {0.0, 0.5, 1.0};
+		int instance = 0;
+		for (int n = 1; n <= 5; n++) {
+			for (int i = 0; i < tau.length; i++) {
+				for (int j = 0; j < r.length; j++) {
+					for (int k = 0; k < eta.length; k++) {
+						WeightedStaticSchedulingWithSetups s = new WeightedStaticSchedulingWithSetups(n, tau[i], r[j], eta[k], 42);
+						StringWriter sOut = new StringWriter();
+						PrintWriter out = new PrintWriter(sOut);
+						s.toFile(out, instance);
+						WeightedStaticSchedulingWithSetups s2 = new WeightedStaticSchedulingWithSetups(new StringReader(sOut.toString()));
+						assertEquals(s.numberOfJobs(), s2.numberOfJobs());
+						for (int job = 0; job < n; job++) {
+							assertEquals(s.getProcessingTime(job), s2.getProcessingTime(job));
+							assertEquals(s.getDueDate(job), s2.getDueDate(job));
+							assertEquals(s.getWeight(job), s2.getWeight(job));
+							assertEquals(s.getSetupTime(job), s2.getSetupTime(job));
+							for (int job2 = 0; job2 < n; job2++) {
+								assertEquals(s.getSetupTime(job, job2), s2.getSetupTime(job, job2));
+							}
+						}
+						Scanner scan = new Scanner(sOut.toString());
+						String line = scan.nextLine();
+						Scanner lineScanner = new Scanner(line);
+						assertEquals("Problem", lineScanner.next());
+						assertEquals("Instance:", lineScanner.next());
+						assertEquals("Instance number", instance, lineScanner.nextInt());
+						lineScanner.close();
+						line = scan.nextLine();
+						lineScanner = new Scanner(line);
+						assertEquals("Problem", lineScanner.next());
+						assertEquals("Size:", lineScanner.next());
+						assertEquals("Number of jobs", n, lineScanner.nextInt());
+						lineScanner.close();
+						assertEquals("Begin Generator Parameters", scan.nextLine());
+						assertEquals("End Generator Parameters", scan.nextLine());
+						assertEquals("Begin Problem Specification", scan.nextLine());
+						assertEquals("Process Times:", scan.nextLine());
+						for (int x = 0; x < n; x++) scan.nextLine();
+						assertEquals("Weights:", scan.nextLine());
+						for (int x = 0; x < n; x++) scan.nextLine();
+						assertEquals("Duedates:", scan.nextLine());
+						for (int x = 0; x < n; x++) scan.nextLine();
+						assertEquals("Setup Times:", scan.nextLine());
+						int n2 = n*n;
+						for (int x = 0; x < n2; x++) scan.nextLine();
+						assertEquals("End Problem Specification", scan.nextLine());
+						scan.close();
+						instance++;
+					}
+				}
+			}
+		}
+	}
 	
 	@Test
 	public void testCorrectNumJobs() {


### PR DESCRIPTION
* Parser for benchmark scheduling instance data files for single machine scheduling problems with weights, duedates, and sequence-dependent setup times (Closes #66 ).
* Other misc minor changes (e.g., github actions version updates, etc)