### PR TITLE
Added new permutation mutation operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2021-4-13
 
 ### Added
+* New mutation operators for permutations:
+    * UniformScrambleMutation: Like ScrambleMutation, but scrambled elements
+      are not necessarily contiguous.
 
 ### Changed
 * Updated dependency to JPT, v2.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-3-30
+## [Unreleased] - 2021-4-13
 
 ### Added
 
 ### Changed
 * Updated dependency to JPT, v2.6.0.
+* Minor optimization to UndoableScrambleMutation, utilizing the JPT updates.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       are not necessarily contiguous.
     * UndoableUniformScrambleMutation: Exactly like UniformScrambleMutation (see above),
       but with support for the undo method of the UndoableMutationOperator interface.
+    * TwoChangeMutation: Mutation operator on permutations that is the equivalent of
+      the classic two change operator, assuming that the permutation represents a cyclic
+      sequence of edges.
 
 ### Changed
 * Updated dependency to JPT, v2.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New mutation operators for permutations:
     * UniformScrambleMutation: Like ScrambleMutation, but scrambled elements
       are not necessarily contiguous.
+    * UndoableUniformScrambleMutation: Exactly like UniformScrambleMutation (see above),
+      but with support for the undo method of the UndoableMutationOperator interface.
 
 ### Changed
 * Updated dependency to JPT, v2.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-4-13
+## [Unreleased] - 2021-4-15
 
 ### Added
 * New mutation operators for permutations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * TwoChangeMutation: Mutation operator on permutations that is the equivalent of
       the classic two change operator, assuming that the permutation represents a cyclic
       sequence of edges.
+    * CycleMutation: Generates a random permutation cycle.
 
 ### Changed
 * Updated dependency to JPT, v2.6.0.

--- a/src/org/cicirello/search/operators/permutations/CycleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/CycleMutation.java
@@ -1,0 +1,118 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.UndoableMutationOperator;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>This class implements a cycle mutation on permutations, where one mutation
+ * generates a random permutation cycle. Given the original parent permutation and
+ * its mutant, a permutation cycle can be defined as follows. Imagine a graph with
+ * n vertexes, where n is the permutation length. Now consider that for each index
+ * i, we define an edge in that graph
+ * between vertex parent[i] and vertex mutant[i]. A permutation cycle consists of
+ * all of the elements from one of the cycles in that graph. The length of a cycle
+ * is the number of elements in it. Consider an example permutation, p1 = [0, 1, 2, 3, 4],
+ * and another permutation, p2 = [0, 3, 2, 1, 4]. This pair of permutations has a
+ * 2-cycle (i.e., a cycle of length 2) consisting of elements 1 and 3.  Consider
+ * a second example, p1 = [0, 1, 2, 3, 4], and p2 = [0, 4, 2, 1, 3]. This example has
+ * a 3-cycle consisting of elements 1, 3, and 4.  Notice that position 1 has elements 1 and 4,
+ * position 4 has elements 4 and 3, and position 3 has elements 3 and 1, so in the
+ * hypothetical graph described above, there would be an edges from 1 to 4, 4 to 3, and 3 to 1,
+ * a cycle of length 3.</p>
+ *
+ * <p>This mutation operator is configured with a parameter to specify the maximum
+ * cycle size. A call to the {@link #mutate mutate} method chooses the cycle size
+ * k uniformly at random from [2, max], and then creates a random k-element cycle.
+ * The combination of k elements is chosen uniformly at random from all possible combinations
+ * of k elements. Note that a 2-cycle is simply a swap.</p>
+ *
+ * <p>The runtime of
+ * the {@link #mutate(Permutation) mutate} method is O(min(n, max<sup>2</sup>)), and derives
+ * from the combination of algorithms utilized by the {@link RandomIndexer RandomIndexer}
+ * class in sampling k random integers. For small values of max, the runtime is essentially
+ * constant. The runtime of the {@link #undo(Permutation) undo} method is
+ * O(max).</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ * @version 4.15.2021
+ */
+public final class CycleMutation implements UndoableMutationOperator<Permutation> {
+	
+	private int[] indexes;
+	private final int bound;
+	
+	/**
+	 * Constructs an CycleMutation mutation operator.
+	 * @param maxCycleLength The maximum length cycle to generate,
+	 * which must be at least 2.
+	 * @throws IllegalArgumentException if maxCycleLength &lt; 2.
+	 */
+	public CycleMutation(int maxCycleLength) {
+		if (maxCycleLength < 2) throw new IllegalArgumentException("maxCycleLength too low");
+		bound = maxCycleLength - 1;
+	}
+	
+	@Override
+	public final void mutate(Permutation c) {
+		if (c.length() >= 2) {
+			indexes = RandomIndexer.sample(
+				c.length(),
+				2 + RandomIndexer.nextInt(bound < c.length() ? bound : c.length() - 1),
+				(int[])null
+			);
+			if (indexes.length > 2) {
+				for (int j = indexes.length - 1; j > 0; j--) {
+					int i = RandomIndexer.nextInt(j+1);
+					if (i != j) {
+						int temp = indexes[i];
+						indexes[i] = indexes[j];
+						indexes[j] = temp;
+					}
+				}
+			}
+			c.cycle(indexes);
+		}
+	}
+	
+	@Override
+	public final void undo(Permutation c) {
+		if (c.length() >= 2) {
+			if (indexes.length > 2) {
+				for (int i = 0, j = indexes.length-1; i < j; i++, j--) {
+					int temp = indexes[i];
+					indexes[i] = indexes[j];
+					indexes[j] = temp;
+				}
+			}
+			c.cycle(indexes);
+		}
+	}
+	
+	@Override
+	public CycleMutation split() {
+		return new CycleMutation(bound + 1);
+	}
+}
+

--- a/src/org/cicirello/search/operators/permutations/ReversalMutation.java
+++ b/src/org/cicirello/search/operators/permutations/ReversalMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -39,11 +39,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * the two end points resulting in a complete reversal.  
  * On average, a reversal mutation moves approximately n/3 elements.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.4.2019
+ * @version 4.14.2021
  */
 public class ReversalMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	

--- a/src/org/cicirello/search/operators/permutations/ScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/ScrambleMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -38,11 +38,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * the two end points.  
  * On average, a scramble mutation moves approximately n/3 elements.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.8.2020
+ * @version 4.13.2021
  */
 public class ScrambleMutation implements MutationOperator<Permutation> {
 

--- a/src/org/cicirello/search/operators/permutations/SwapMutation.java
+++ b/src/org/cicirello/search/operators/permutations/SwapMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -37,11 +37,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * the {@link #mutate(Permutation) mutate} and {@link #undo(Permutation) undo} methods is O(1)
  * since only a constant number of assignments are necessary to execute a swap.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
+ * @version 4.15.2021
  */
 public class SwapMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 

--- a/src/org/cicirello/search/operators/permutations/TwoChangeIterator.java
+++ b/src/org/cicirello/search/operators/permutations/TwoChangeIterator.java
@@ -1,0 +1,114 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.MutationIterator;
+import org.cicirello.permutations.Permutation;
+
+/**
+ * Internal (package-private) class implementing an iterator over
+ * all two changes.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ * @version 4.15.2021 
+ */
+final class TwoChangeIterator implements MutationIterator {
+	
+	// NOTE: Much of this implementation has been adapted
+	// from WindowLimitedReversalIterator, in the following
+	// ways: (1) the window limit w is p.length()-3; and
+	// (2) to avoid redundant reversals logically equivalent
+	// to the same two change, excludes reversals that include
+	// right end.
+	
+	private boolean rolled;
+	private boolean hasMore;
+	private final Permutation p;
+	private final int w;
+	private int i;
+	private int j;
+	private int u;
+	private int v;
+	private int x;
+	private int y;
+	
+	TwoChangeIterator(Permutation p) {
+		this.p = p;
+		this.w = p.length() - 3;
+		hasMore = p.length() >= 4;
+		// Default inits:
+		//    y = x = u = v = i = j = 0;
+		//    rolled = false;
+	}
+	
+	@Override
+	public boolean hasNext() {
+		return hasMore && !rolled;
+	}
+	
+	@Override
+	public void nextMutant() {
+		if (!hasMore) throw new IllegalStateException("no neighbors left");
+		if (rolled) throw new IllegalStateException("illegal to call nextMutant after calling rollback");
+		if (i==j) {
+			 if (w >= 2) v = j = 2;
+			 else v = j = 1;
+		} else {
+			if (u==0 || v==p.length()-2 || v-u>=w-1) {
+				p.reverse(u,v);
+				j++;
+				if (j >= p.length()-1) {
+					i = 0;
+					j = 1;
+				} else {
+					i++;
+				}
+				u = i;
+				v = j;
+			} else {
+				u--;
+				v++;
+			}
+		}
+		p.swap(u, v);
+		if (u == p.length()-3) hasMore = false;
+	}
+	
+	@Override
+	public void setSavepoint() {
+		x = u;
+		y = v;
+	}
+	
+	@Override
+	public void rollback() {
+		if (!rolled) {
+			rolled = true;
+			if (y == 0) {
+				if (v > 0) p.reverse(u,v);
+			} else if (u != x || v != y) {
+				p.reverse(u,v);
+				p.reverse(x,y);
+			}
+		}
+	}
+}

--- a/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
+++ b/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
@@ -21,8 +21,8 @@
 package org.cicirello.search.operators.permutations;
 
 import org.cicirello.search.operators.UndoableMutationOperator;
-//import org.cicirello.search.operators.IterableMutationOperator;
-//import org.cicirello.search.operators.MutationIterator;
+import org.cicirello.search.operators.IterableMutationOperator;
+import org.cicirello.search.operators.MutationIterator;
 import org.cicirello.permutations.Permutation;
 import org.cicirello.math.rand.RandomIndexer;
 
@@ -90,7 +90,7 @@ import org.cicirello.math.rand.RandomIndexer;
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  * @version 4.15.2021
  */
-public final class TwoChangeMutation implements UndoableMutationOperator<Permutation> {
+public final class TwoChangeMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	
 	// needed to implement undo
 	private int a;
@@ -119,6 +119,21 @@ public final class TwoChangeMutation implements UndoableMutationOperator<Permuta
 	@Override
 	public TwoChangeMutation split() {
 		return new TwoChangeMutation();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * <p>The worst case runtime of the {@link MutationIterator#hasNext} and the 
+	 * {@link MutationIterator#setSavepoint} methods of the {@link MutationIterator} 
+	 * created by this method is O(1).  The amortized runtime of the 
+	 * {@link MutationIterator#nextMutant} method is O(1).
+	 * And the worst case runtime of the 
+	 * {@link MutationIterator#rollback} method 
+	 * is O(n), where n is the length of the Permutation.</p>
+	 */
+	@Override
+	public MutationIterator iterator(Permutation p) {
+		return new TwoChangeIterator(p);
 	}
 	
 	/*

--- a/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
+++ b/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
@@ -83,7 +83,7 @@ import org.cicirello.math.rand.RandomIndexer;
  * we can't really say (at least not in a problem independent way) which might be better.</p>
  *
  * <p>For any given permutation of length n, there are n*(n-3)/2 possible two-change
- * neighbors. For permutations of length n &lt 4, the TwoChangeMutation operator
+ * neighbors. For permutations of length n &lt; 4, the TwoChangeMutation operator
  * makes no changes, as there are no two-change neighbors of permutations of that size.</p> 
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 

--- a/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
+++ b/src/org/cicirello/search/operators/permutations/TwoChangeMutation.java
@@ -1,0 +1,162 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.UndoableMutationOperator;
+//import org.cicirello.search.operators.IterableMutationOperator;
+//import org.cicirello.search.operators.MutationIterator;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>This class implements the classic two-change operator as a mutation operator 
+ * for permutations. The two-change operator originated as a local search operator 
+ * for the TSP that removes two edges from a tour of the cities of a TSP and replaces
+ * them with two different edges such that the result is a valid tour of the cities.
+ * This implementation is not strictly for the TSP, and will operate on a permutation
+ * regardless of what that permutation represents. However, it assumes that the 
+ * permutation represents a cyclic sequence of edges, and specifically that if two elements
+ * are adjacent in the permutation that it corresponds to an undirected edge between the
+ * elements. For example, consider the permutation, p = [2, 1, 4, 0, 3], of the first 5 
+ * non-negative integers. Now imagine that we have a graph with 5 vertexes, labeled 0 to
+ * 4. This example permutation would correspond to a set of undirected edges: 
+ * { (2, 1), (1, 4), (4, 0), (0, 3), (3, 2) }. Notice that we included (3, 2) here in that
+ * the set of edges represented by the permutation is cyclic and includes an edge between
+ * the two endpoints.  The classic two-change removes two edges and replaces them with two 
+ * different edges that reconnect a valid traversal of all elements. One way of implementing
+ * the equivalent of this as an operator on permutations is to reverse a subsequence.
+ * For example, consider reversing the first 3 elements, which gives you: p = [4, 1, 2, 0, 3],
+ * which under the edge interpretation corresponds to the edges: 
+ * { (4, 1), (1, 2), (2, 0), (0, 3), (3, 4) }. Remember that we are interpreting the edges
+ * as undirected edges, and that there are exactly two that have changed: (4, 0) and (3, 2)
+ * were removed, and replaced by (2, 0) and (3, 4).</p> 
+ * 
+ * <p>Technically, if you wanted to use the approximate equivalent of a two change operator,
+ * you could use the {@link ReversalMutation} class. The reason is that every two change
+ * is equivalent to a reversal. However, not every reversal is equivalent to a two change.
+ * If you reverse the entire permutation, you don't actually change any edges, if the permutation
+ * represents a cyclic set of undirected edges. Likewise, if you reverse an n-1 length sequence
+ * of elements, you also don't change any edges. This TwoChangeMutation class implements a
+ * two change operator that always produces a mutant that is the equivalent to changing
+ * two edges (if that is what the permutation represents). For example, it won't reverse
+ * the entire permutation, and also won't reverse a subpermutation of length n-1. Additionally,
+ * simply viewing reversals as two changes leads to redundancy (e.g., reversing the
+ * first k elements changes the same two edges as reversing the last n-k elements), so if
+ * your aim is to perform two changes, and if you want all possible two changes to be
+ * equally likely when generating a random mutant, then the {@link ReversalMutation} class
+ * will not give you that since it will be biased in favor of the two changes that have
+ * multiple equivalent reversals. This TwoChangeMutation class is implemented such that
+ * all two changes of a permutation are approximately equally likely.</p>
+ *
+ * <p>Also note that this TwoChangeMutation doesn't guarantee implementation by reversals.
+ * It only guarantees that every mutation is equivalent to a two change (under the interpretation
+ * of a permutation representing a cyclic set of edges), and that all possible such
+ * two changes are equally likely. Under this assumption some two changes can be generated
+ * faster than by a reversal.</p>
+ *
+ * <p>The runtime (worst case and average case) of both
+ * the {@link #mutate(Permutation) mutate} and {@link #undo(Permutation) undo} methods is O(n),
+ * where n is the length of the permutation. During a single call to one of these methods,
+ * at most n/2 elements will change locations. Thus, this is roughly twice as fast as 
+ * the {@link ReversalMutation} class, which can move as many as n elements during a single
+ * call to these methods. If the set of edges interpretation applies to your problem, then
+ * the TwoChangeMutation may be a better choice than ReversalMutation. At the very least it
+ * will compute mutants faster. If that interpretation doesn't apply to your problem, then
+ * we can't really say (at least not in a problem independent way) which might be better.</p>
+ *
+ * <p>For any given permutation of length n, there are n*(n-3)/2 possible two-change
+ * neighbors. For permutations of length n &lt 4, the TwoChangeMutation operator
+ * makes no changes, as there are no two-change neighbors of permutations of that size.</p> 
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ * @version 4.15.2021
+ */
+public final class TwoChangeMutation implements UndoableMutationOperator<Permutation> {
+	
+	// needed to implement undo
+	private int a;
+	private int b;
+	
+	/**
+	 * Constructs an TwoChangeMutation mutation operator.
+	 */
+	public TwoChangeMutation() {
+	}
+
+	@Override
+	public final void mutate(Permutation c) {
+		if (c.length() >= 4) {
+			internalMutate(c, RandomIndexer.nextInt(c.length()), 1 + RandomIndexer.nextInt(c.length()-3));
+		}
+	}
+	
+	@Override
+	public final void undo(Permutation c) {
+		if (c.length() >= 4) {
+			internalMutate(c);
+		}
+	}
+	
+	@Override
+	public TwoChangeMutation split() {
+		return new TwoChangeMutation();
+	}
+	
+	/*
+	 * package-private to facilitate unit-testing
+	 */
+	final void internalMutate(Permutation c, int first, int delta) {
+		b = first + delta;
+		if (b >= c.length()) {
+			a = b - c.length() + 1;
+			b = first - 1;				
+		} else {
+			a = first;
+		}
+		internalMutate(c);
+	}
+	
+	private void internalMutate(Permutation c) {
+		if (b - a < (c.length() >> 1)) {
+			c.reverse(a, b);
+		} else {
+			int rightCount = c.length() - b - 1;
+			int i=a-1; 
+			int j=b+1;
+			if (a < rightCount) {
+				for ( ; i >= 0; i--, j++) {
+					c.swap(i, j);
+				}
+				c.reverse(j, c.length()-1);
+			} else if (a > rightCount) {
+				for ( ; j < c.length(); i--, j++) {
+					c.swap(i, j);
+				}
+				c.reverse(0, i);
+			} else {
+				for ( ; i >= 0; i--, j++) {
+					c.swap(i, j);
+				}
+			}
+		}
+	}
+}

--- a/src/org/cicirello/search/operators/permutations/UndoableScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/UndoableScrambleMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -42,11 +42,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * O(n) extra memory required to store the prior permutation state, as well as the time
  * associated with copying that state prior to mutation.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.8.2020
+ * @version 4.13.2021
  */
 public class UndoableScrambleMutation extends Permutation.Mechanic implements UndoableMutationOperator<Permutation> {
 
@@ -77,13 +75,9 @@ public class UndoableScrambleMutation extends Permutation.Mechanic implements Un
 		// If so, undo the mutation.
 		if (previous == c) {
 			if (indexes[0] < indexes[1]) {
-				for (int i = indexes[0]; i <= indexes[1]; i++) {
-					set(c, i, last[i]);
-				}
+				set(c, last, indexes[0], indexes[0], indexes[1]-indexes[0]+1);
 			} else {
-				for (int i = indexes[1]; i <= indexes[0]; i++) {
-					set(c, i, last[i]);
-				}
+				set(c, last, indexes[1], indexes[1], indexes[0]-indexes[1]+1);
 			}			
 		} 
 	}

--- a/src/org/cicirello/search/operators/permutations/UndoableUniformScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/UndoableUniformScrambleMutation.java
@@ -1,0 +1,114 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.UndoableMutationOperator;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>This class implements a scramble mutation on permutations, where one mutation
+ * consists in randomizing the order of a non-contiguous subset of the permutation
+ * elements. It is controlled by a parameter U, which is the probability that an 
+ * element is included in the scramble. On average, you can expect U*n elements
+ * to be randomized, where n is the length of the permutation.
+ * This version of uniform scramble mutation also supports the undo method.</p>
+ * <p>The worst case and average case runtime of 
+ * the {@link #mutate(Permutation) mutate} 
+ * method is O(n),
+ * where n is the length of the permutation.
+ * The worst case runtime of the {@link #undo(Permutation) undo} method
+ * is also O(n), but its average runtime is O(U*n).</p>
+ * <p>If you don't need the {@link #undo(Permutation) undo} method, then it is recommended
+ * that you instead use the {@link UniformScrambleMutation} class instead to avoid the
+ * O(n) extra memory required to store the prior permutation state, as well as the time
+ * associated with copying that state prior to mutation.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ * @version 4.13.2021
+ */
+public final class UndoableUniformScrambleMutation extends Permutation.Mechanic implements UndoableMutationOperator<Permutation> {
+	
+	private final double u;
+	private final boolean guaranteeChange;
+	
+	private int[] last;
+	private Permutation previous;
+	private int[] indexes;
+	
+	/**
+	 * Constructs a UndoableUniformScrambleMutation mutation operator.
+	 * @param u The probability that an element is included in a
+	 * scramble. If the permutation length is n, you can expect 
+	 * approximately u*n elements on average to be scrambled.
+	 * @throws IllegalArgumentException if u is negative or if u is greater than 1.0.
+	 */
+	public UndoableUniformScrambleMutation(double u) { 
+		this(u, false);
+	}
+	
+	/**
+	 * Constructs a UndoableUniformScrambleMutation mutation operator.
+	 * @param u The probability that an element is included in a
+	 * scramble. If the permutation length is n, you can expect 
+	 * approximately u*n elements on average to be scrambled.
+	 * @param guaranteeChange If true, then the {@link #mutate(Permutation) mutate}
+	 * method will be guaranteed to change the locations of at least 2 elements.
+	 * Otherwise, if false, it may be possible (e.g., for low values of u) for
+	 * the mutate method not to change anything during some calls.
+	 * @throws IllegalArgumentException if u is negative or if u is greater than 1.0.
+	 */
+	public UndoableUniformScrambleMutation(double u, boolean guaranteeChange) { 
+		if (u < 0 || u > 1.0) throw new IllegalArgumentException("u must be in [0.0, 1.0].");
+		this.u = u;
+		this.guaranteeChange = guaranteeChange;
+	}
+	
+	@Override
+	public final void mutate(Permutation c) {
+		if (c.length() >= 2) {
+			previous = c;
+			last = c.toArray();
+			indexes = RandomIndexer.sample(c.length(), u);
+			if (guaranteeChange && indexes.length < 2) {
+				indexes = RandomIndexer.nextIntPair(c.length(), null);
+			}
+			c.scramble(indexes);
+		}
+	}
+	
+	@Override
+	public final void undo(Permutation c) {
+		// Verify that c was the most recently mutated permutation.
+		// If so, undo the mutation.
+		if (previous == c) {
+			for (int i = 0; i < indexes.length; i++) {
+				set(c, indexes[i], last[indexes[i]]);
+			}
+		} 
+	}
+	
+	@Override
+	public UndoableUniformScrambleMutation split() {
+		return new UndoableUniformScrambleMutation(u, guaranteeChange);
+	}
+}

--- a/src/org/cicirello/search/operators/permutations/UniformScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/UniformScrambleMutation.java
@@ -1,0 +1,90 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.MutationOperator;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>This class implements a scramble mutation on permutations, where one mutation
+ * consists in randomizing the order of a non-contiguous subset of the permutation
+ * elements. It is controlled by a parameter U, which is the probability that an 
+ * element is included in the scramble. On average, you can expect U*n elements
+ * to be randomized, where n is the length of the permutation.</p>
+ * <p>The worst case runtime of 
+ * the {@link #mutate(Permutation) mutate} method is O(n), and the
+ * average case is O(U*n),
+ * where n is the length of the permutation.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ * @version 4.13.2021
+ */
+public final class UniformScrambleMutation implements MutationOperator<Permutation> {
+	
+	private final double u;
+	private final boolean guaranteeChange;
+	
+	/**
+	 * Constructs a UniformScrambleMutation mutation operator.
+	 * @param u The probability that an element is included in a
+	 * scramble. If the permutation length is n, you can expect 
+	 * approximately u*n elements on average to be scrambled.
+	 * @throws IllegalArgumentException if u is negative or if u is greater than 1.0.
+	 */
+	public UniformScrambleMutation(double u) { 
+		this(u, false);
+	}
+	
+	/**
+	 * Constructs a UniformScrambleMutation mutation operator.
+	 * @param u The probability that an element is included in a
+	 * scramble. If the permutation length is n, you can expect 
+	 * approximately u*n elements on average to be scrambled.
+	 * @param guaranteeChange If true, then the {@link #mutate(Permutation) mutate}
+	 * method will be guaranteed to change the locations of at least 2 elements.
+	 * Otherwise, if false, it may be possible (e.g., for low values of u) for
+	 * the mutate method not to change anything during some calls.
+	 * @throws IllegalArgumentException if u is negative or if u is greater than 1.0.
+	 */
+	public UniformScrambleMutation(double u, boolean guaranteeChange) { 
+		if (u < 0 || u > 1.0) throw new IllegalArgumentException("u must be in [0.0, 1.0].");
+		this.u = u;
+		this.guaranteeChange = guaranteeChange;
+	}
+	
+	@Override
+	public final void mutate(Permutation c) {
+		if (c.length() >= 2) {
+			int[] indexes = RandomIndexer.sample(c.length(), u);
+			if (guaranteeChange && indexes.length < 2) {
+				indexes = RandomIndexer.nextIntPair(c.length(), null);
+			}
+			c.scramble(indexes);
+		}
+	}
+	
+	@Override
+	public UniformScrambleMutation split() {
+		return new UniformScrambleMutation(u, guaranteeChange);
+	}
+}

--- a/src/org/cicirello/search/operators/permutations/WindowLimitedScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/WindowLimitedScrambleMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -42,11 +42,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * in Proceedings of the 8th International Conference on Bioinspired Information and 
  * Communications Technologies, pages 28–35, December 2014.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
+ * @version 4.13.2021
  */
 public final class WindowLimitedScrambleMutation extends ScrambleMutation {
 

--- a/src/org/cicirello/search/operators/permutations/WindowLimitedUndoableScrambleMutation.java
+++ b/src/org/cicirello/search/operators/permutations/WindowLimitedUndoableScrambleMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -41,11 +41,9 @@ import org.cicirello.math.rand.RandomIndexer;
  * in Proceedings of the 8th International Conference on Bioinspired Information and 
  * Communications Technologies, pages 28–35, December 2014.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
+ * @version 4.13.2021
  */
 public final class WindowLimitedUndoableScrambleMutation extends UndoableScrambleMutation {
 

--- a/tests/org/cicirello/search/operators/permutations/IterableMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/IterableMutationTests.java
@@ -88,7 +88,7 @@ public class IterableMutationTests {
 			validate(m, original, expectedNeighbors);
 		}
 		// Now test for n >= 4.
-		for (int n = 4; n <= 6; n++) {
+		for (int n = 4; n <= 7; n++) {
 			Permutation original = new Permutation(n);
 			// generate the set of actual neigbors of a random permutation of length n
 			HashSet<Permutation> expectedNeighbors = new HashSet<Permutation>();
@@ -367,7 +367,7 @@ public class IterableMutationTests {
 			);
 			assertFalse("verify no next if rolled back", iter.hasNext());
 		}
-		// test rollback two steps after setSavepoint
+		// test rollback one step after setSavepoint
 		for (int i = 0; i < count-1; i++) {
 			iter = mutation.iterator(p);
 			Permutation saved = p.copy();
@@ -378,6 +378,24 @@ public class IterableMutationTests {
 					iter.setSavepoint();
 					saved = p.copy();
 				} else if (j > i) {
+					break;
+				}
+				j++;
+			}
+			iter.rollback();
+			assertEquals("rollback one step after setSavepoint, verify rolled back to last savepoint, original="+original+" i="+i, saved, p);
+		}
+		// test rollback two steps after setSavepoint
+		for (int i = 0; i < count-1; i++) {
+			iter = mutation.iterator(p);
+			Permutation saved = p.copy();
+			int j = 0;
+			while (iter.hasNext()) {
+				iter.nextMutant();
+				if (j==i) {
+					iter.setSavepoint();
+					saved = p.copy();
+				} else if (j > i+1) {
 					break;
 				}
 				j++;

--- a/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
@@ -295,6 +295,34 @@ public class PermutationMutationTests {
 	}
 	
 	@Test
+	public void testUniformScramble() {
+		UniformScrambleMutation m = new UniformScrambleMutation(0.0, true);
+		mutateTester(m);
+		splitTester(m);
+		m = new UniformScrambleMutation(1.0);
+		mutateTester(m);
+		splitTester(m);
+		m = new UniformScrambleMutation(0.5, true);
+		mutateTester(m);
+		splitTester(m);
+		m = new UniformScrambleMutation(0.0, false);
+		for (int n = 0; n <= 6; n++) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(p1);
+			m.mutate(p2);
+			assertEquals(p1, p2);
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UniformScrambleMutation(-0.000001)
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UniformScrambleMutation(1.000001)
+		);
+	}
+	
+	@Test
 	public void testUndoableScramble() {
 		UndoableScrambleMutation m = new UndoableScrambleMutation();
 		undoTester(m);

--- a/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
@@ -199,6 +199,123 @@ public class PermutationMutationTests {
 	}
 	
 	@Test
+	public void testCycle2() {
+		CycleMutation m = new CycleMutation(2);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		// Verify mutations are 2-cycles (i.e., swaps)
+		for (int n = 2; n <= 6; n++) {
+			Permutation p = new Permutation(n);
+			for (int t = 0; t < NUM_RAND_TESTS; t++) {
+				Permutation mutant = new Permutation(p);
+				m.mutate(mutant);
+				int a, b;
+				for (a = 0; a < p.length() && p.get(a) == mutant.get(a); a++);
+				for (b = p.length()-1; b >= 0 && p.get(b) == mutant.get(b); b--);
+				assertTrue("verify elements changed", a <= b);
+				assertEquals("Verify elements swapped", p.get(a), mutant.get(b));
+				assertEquals("Verify elements swapped", p.get(b), mutant.get(a));
+				for (int i = a+1; i < b; i++) {
+					assertEquals("Verify interior elements not changed", p.get(i), mutant.get(i));
+				}
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new CycleMutation(1)
+		);
+	}
+	
+	@Test
+	public void testCycle3() {
+		CycleMutation m = new CycleMutation(3);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		// Verify mutations are 2-cycles or 3-cycles
+		int[] indexes = new int[3];
+		boolean[] foundCycleLength = new boolean[4];
+		for (int n = 2; n <= 6; n++) {
+			Permutation p = new Permutation(n);
+			for (int t = 0; t < NUM_RAND_TESTS; t++) {
+				Permutation mutant = new Permutation(p);
+				m.mutate(mutant);
+				int size = 0;
+				for (int i = 0; i < p.length(); i++) {
+					if (p.get(i) != mutant.get(i)) {
+						if (size == indexes.length) {
+							fail("cycle is too large");
+						}
+						indexes[size] = i;
+						size++;
+					}
+				}
+				foundCycleLength[size] = true;
+				int[] inv = p.getInverse();
+				boolean[] cycleCheck = new boolean[n];
+				int j = indexes[0];
+				int next = p.get(j);
+				for (int i = 0; i < size; i++) {
+					assertFalse(cycleCheck[next]);
+					cycleCheck[next] = true;
+					next = mutant.get(j);
+					j = inv[next];
+					assertNotEquals(p.get(j), mutant.get(j));
+				}
+				assertTrue(cycleCheck[next]);
+			}
+		}
+		for (int i = 2; i < foundCycleLength.length; i++) {
+			assertTrue(foundCycleLength[i]);
+		}
+	}
+	
+	@Test
+	public void testCycle4() {
+		CycleMutation m = new CycleMutation(4);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		// Verify mutations are 2-cycles, 3-cycles, or 4-cycles
+		int[] indexes = new int[4];
+		boolean[] foundCycleLength = new boolean[5];
+		for (int n = 2; n <= 6; n++) {
+			Permutation p = new Permutation(n);
+			for (int t = 0; t < NUM_RAND_TESTS; t++) {
+				Permutation mutant = new Permutation(p);
+				m.mutate(mutant);
+				int size = 0;
+				for (int i = 0; i < p.length(); i++) {
+					if (p.get(i) != mutant.get(i)) {
+						if (size == indexes.length) {
+							fail("cycle is too large");
+						}
+						indexes[size] = i;
+						size++;
+					}
+				}
+				foundCycleLength[size] = true;
+				int[] inv = p.getInverse();
+				boolean[] cycleCheck = new boolean[n];
+				int j = indexes[0];
+				int next = p.get(j);
+				for (int i = 0; i < size; i++) {
+					assertFalse(cycleCheck[next]);
+					cycleCheck[next] = true;
+					next = mutant.get(j);
+					j = inv[next];
+					assertNotEquals(p.get(j), mutant.get(j));
+				}
+				assertTrue(cycleCheck[next]);
+			}
+		}
+		for (int i = 2; i < foundCycleLength.length; i++) {
+			assertTrue(foundCycleLength[i]);
+		}
+	}
+	
+	@Test
 	public void testSwap() {
 		SwapMutation m = new SwapMutation();
 		undoTester(m);

--- a/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
@@ -373,6 +373,94 @@ public class PermutationMutationTests {
 	}
 	
 	@Test
+	public void testTwoChange() {
+		TwoChangeMutation m = new TwoChangeMutation();
+		undoTester(m);
+		mutateTester(m, 4);
+		splitTester(m);
+		// For n < 4, this mutation operator should do nothing:
+		for (int n = 0; n < 4; n++) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(p1);
+			m.mutate(p2);
+			assertEquals(p1, p2);
+		}
+		// test internal mutate for n = 4
+		int[] perm = {0, 1, 2, 3};
+		Permutation[] expected = {
+			new Permutation(new int[] {1, 0, 2, 3}),
+			new Permutation(new int[] {0, 2, 1, 3}),
+			new Permutation(new int[] {0, 1, 3, 2}),
+			new Permutation(new int[] {0, 2, 1, 3})
+		};
+		for (int i = 0; i < expected.length; i++) {
+			Permutation p = new Permutation(perm);
+			m.internalMutate(p, i, 1);
+			assertEquals(expected[i], p);
+		}
+		// test internal mutate for n = 5
+		perm = new int[] {0, 1, 2, 3, 4};
+		Permutation[][] expected2 = {
+			{ 
+				new Permutation(new int[] {1, 0, 2, 3, 4}),
+				new Permutation(new int[] {0, 2, 1, 3, 4}),
+				new Permutation(new int[] {0, 1, 3, 2, 4}),
+				new Permutation(new int[] {0, 1, 2, 4, 3}),
+				new Permutation(new int[] {4, 1, 2, 3, 0})
+			},
+			{ 
+				new Permutation(new int[] {0, 1, 2, 4, 3}),
+				new Permutation(new int[] {4, 1, 2, 3, 0}),
+				new Permutation(new int[] {1, 0, 2, 3, 4}),
+				new Permutation(new int[] {0, 2, 1, 3, 4}),
+				new Permutation(new int[] {0, 1, 3, 2, 4})
+			}
+		};
+		for (int i = 0; i < expected2.length; i++) {
+			for (int j = 0; j < expected2[i].length; j++) {
+				Permutation p = new Permutation(perm);
+				m.internalMutate(p, j, i+1);
+				assertEquals(expected2[i][j], p);
+			}
+		}
+		// test internal mutate for n = 6
+		perm = new int[] {0, 1, 2, 3, 4, 5};
+		expected2 = new Permutation[][] {
+			{ 
+				new Permutation(new int[] {1, 0, 2, 3, 4, 5}),
+				new Permutation(new int[] {0, 2, 1, 3, 4, 5}),
+				new Permutation(new int[] {0, 1, 3, 2, 4, 5}),
+				new Permutation(new int[] {0, 1, 2, 4, 3, 5}),
+				new Permutation(new int[] {0, 1, 2, 3, 5, 4}),
+				new Permutation(new int[] {5, 1, 2, 3, 4, 0})
+			},
+			{ 
+				new Permutation(new int[] {2, 1, 0, 3, 4, 5}),
+				new Permutation(new int[] {0, 3, 2, 1, 4, 5}),
+				new Permutation(new int[] {0, 1, 4, 3, 2, 5}),
+				new Permutation(new int[] {0, 1, 2, 5, 4, 3}),
+				new Permutation(new int[] {0, 3, 2, 1, 4, 5}),
+				new Permutation(new int[] {0, 1, 4, 3, 2, 5})
+			},
+			{ 
+				new Permutation(new int[] {0, 1, 2, 3, 5, 4}),
+				new Permutation(new int[] {5, 1, 2, 3, 4, 0}),
+				new Permutation(new int[] {1, 0, 2, 3, 4, 5}),
+				new Permutation(new int[] {0, 2, 1, 3, 4, 5}),
+				new Permutation(new int[] {0, 1, 3, 2, 4, 5}),
+				new Permutation(new int[] {0, 1, 2, 4, 3, 5})
+			}
+		};
+		for (int i = 0; i < expected2.length; i++) {
+			for (int j = 0; j < expected2[i].length; j++) {
+				Permutation p = new Permutation(perm);
+				m.internalMutate(p, j, i+1);
+				assertEquals(expected2[i][j], p);
+			}
+		}
+	}
+	
+	@Test
 	public void testRotation() {
 		RotationMutation m = new RotationMutation();
 		undoTester(m);

--- a/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
@@ -323,6 +323,37 @@ public class PermutationMutationTests {
 	}
 	
 	@Test
+	public void testUndoableUniformScramble() {
+		UndoableUniformScrambleMutation m = new UndoableUniformScrambleMutation(0.0, true);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		m = new UndoableUniformScrambleMutation(1.0);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		m = new UndoableUniformScrambleMutation(0.5, true);
+		undoTester(m);
+		mutateTester(m);
+		splitTester(m);
+		m = new UndoableUniformScrambleMutation(0.0, false);
+		for (int n = 0; n <= 6; n++) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(p1);
+			m.mutate(p2);
+			assertEquals(p1, p2);
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UndoableUniformScrambleMutation(-0.000001)
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UndoableUniformScrambleMutation(1.000001)
+		);
+	}
+	
+	@Test
 	public void testUndoableScramble() {
 		UndoableScrambleMutation m = new UndoableScrambleMutation();
 		undoTester(m);

--- a/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
+++ b/tests/org/cicirello/search/operators/permutations/PermutationMutationTests.java
@@ -458,6 +458,53 @@ public class PermutationMutationTests {
 				assertEquals(expected2[i][j], p);
 			}
 		}
+		// test internal mutate for n = 7.
+		perm = new int[] {0, 1, 2, 3, 4, 5, 6};
+		expected2 = new Permutation[][] {
+			{ 
+				new Permutation(new int[] {1, 0, 2, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 2, 1, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 3, 2, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 4, 3, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 3, 5, 4, 6}),
+				new Permutation(new int[] {0, 1, 2, 3, 4, 6, 5}),
+				new Permutation(new int[] {6, 1, 2, 3, 4, 5, 0})
+			},
+			{ 
+				new Permutation(new int[] {2, 1, 0, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 3, 2, 1, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 4, 3, 2, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 5, 4, 3, 6}),
+				new Permutation(new int[] {0, 1, 2, 3, 6, 5, 4}),
+				new Permutation(new int[] {5, 1, 2, 3, 4, 0, 6}),
+				new Permutation(new int[] {0, 6, 2, 3, 4, 5, 1})
+			},
+			{ 
+				new Permutation(new int[] {0, 1, 2, 3, 6, 5, 4}),
+				new Permutation(new int[] {5, 1, 2, 3, 4, 0, 6}),
+				new Permutation(new int[] {0, 6, 2, 3, 4, 5, 1}),
+				new Permutation(new int[] {2, 1, 0, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 3, 2, 1, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 4, 3, 2, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 5, 4, 3, 6})
+			},
+			{ 
+				new Permutation(new int[] {0, 1, 2, 3, 4, 6, 5}),
+				new Permutation(new int[] {6, 1, 2, 3, 4, 5, 0}),
+				new Permutation(new int[] {1, 0, 2, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 2, 1, 3, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 3, 2, 4, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 4, 3, 5, 6}),
+				new Permutation(new int[] {0, 1, 2, 3, 5, 4, 6})
+			}
+		};
+		for (int i = 0; i < expected2.length; i++) {
+			for (int j = 0; j < expected2[i].length; j++) {
+				Permutation p = new Permutation(perm);
+				m.internalMutate(p, j, i+1);
+				assertEquals(expected2[i][j], p);
+			}
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
## Summary
Added new permutation mutation operators, including UniformScrambleMutation, TwoChangeMutation, and CycleMutation. Other minor changes to permutation mutation ops, such as documentation updates, code optimizations and other code improvements.

## Closing Issues
* Closes #228 
* Closes #230 
* Closes #231 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
