### PR TITLE
Migrated build process to target Java 11

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,5 +1,7 @@
 build = "mvn"
 
+jdk11 = true
+
 # don't run eslint... it is for js and will detect false positives 
 # in javadoc directories.
 
@@ -31,6 +33,6 @@ ignore = ["PREDICTABLE_RANDOM", "PATH_TRAVERSAL_IN", "PATH_TRAVERSAL_OUT"]
 
 ignoreFiles = """
 docs/api/jquery/
-tests/
+src/test/
 *.js
 """

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-9-27
+## [Unreleased] - 2021-9-30
 
 ### Added
 
 ### Changed
+* Beginning with release 3.0.0, the minimum supported Java version is now Java 11+.
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,8 +210,7 @@
   
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.release>11</maven.compiler.release>
 	</properties>
   
 	<build>
@@ -221,8 +220,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -251,7 +249,6 @@
 					</execution>
 				</executions>
 				<configuration>
-					<source>1.8</source>
 					<failOnWarnings>true</failOnWarnings>
 					<failOnError>true</failOnError>
 					<additionalJOptions>
@@ -264,10 +261,9 @@
 					<nosince>true</nosince>
 					<overview>${project.build.sourceDirectory}/overview.html</overview>
 					<notimestamp>true</notimestamp>
-					<links>
-						<link>https://docs.oracle.com/javase/8/docs/api</link>
+					<!--links-->
 						<!--link>https://jpt.cicirello.org/api</link-->
-					</links>
+					<!--/links-->
 					<bottom><![CDATA[Copyright &copy; 2002-2021 <a href=\"https://www.cicirello.org/\" target=_top>Vincent A. Cicirello</a>.  All rights reserved.]]></bottom>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## Summary
We've been executing the build with JDK 11, but targeting Java 8+. We are changing the minimum supported Java version to Java 11. The build process has been migrated to target Java 11. The purpose of this change is multifaceted. First, it gives us access to newer Java features. Second, the dependencies have been migrated to Java 11, so in order to upgrade dependency versions, this migration to Java 11 is necessary.

## Closing Issues
Closes #287 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
