### PR TITLE
Crossover operators for BitVectors: single-point, two-point, k-point, and uniform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Crossover operators for BitVectors, including:
     * Single-point crossover
     * Two-point crossover
-	* K-point crossover
+    * K-point crossover
   * The following selection operators:
     * FitnessProportionalSelection
     * StochasticUniversalSampling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-12-19
+## [Unreleased] - 2021-12-20
 
 ### Added
 * Enhancements to BitVector class, including:
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Crossover features (mirrors the existing features of mutation operators):
     * CrossoverOperator interface for defining custom crossover operators.
     * Support for hybrid crossover operators (e.g., picking randomly from set of crossover operators).
+  * Crossover operators for BitVectors, including:
+    * Single-point crossover
+    * Two-point crossover
   * The following selection operators:
     * FitnessProportionalSelection
     * StochasticUniversalSampling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Crossover operators for BitVectors, including:
     * Single-point crossover
     * Two-point crossover
+	* K-point crossover
   * The following selection operators:
     * FitnessProportionalSelection
     * StochasticUniversalSampling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Enhancements to BitVector class, including:
   * A new method to exchange a sequence of bits between two BitVectors.
+  * A new method to exchange a selection of bits, specified with a bit mask, between two BitVectors.
 * Generational evolutionary algorithms, including the following features and functionality:
   * The following EA variations:
     * Standard generational model, parents replaced by children, crossover and mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Single-point crossover
     * Two-point crossover
     * K-point crossover
+    * Uniform crossover
   * The following selection operators:
     * FitnessProportionalSelection
     * StochasticUniversalSampling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Enhancements to BitVector class, including:
   * A new method to exchange a sequence of bits between two BitVectors.
   * A new method to exchange a selection of bits, specified with a bit mask, between two BitVectors.
+  * A new constructor, BitVector(length, p), that generates random bit masks given probability p of a 1-bit.
 * Generational evolutionary algorithms, including the following features and functionality:
   * The following EA variations:
     * Standard generational model, parents replaced by children, crossover and mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-12-16
+## [Unreleased] - 2021-12-18
 
 ### Added
+* Enhancements to BitVector class, including:
+  * A new method to exchange a sequence of bits between two BitVectors.
 * Generational evolutionary algorithms, including the following features and functionality:
   * The following EA variations:
     * Standard generational model, parents replaced by children, crossover and mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-12-18
+## [Unreleased] - 2021-12-19
 
 ### Added
 * Enhancements to BitVector class, including:

--- a/src/main/java/org/cicirello/search/concurrent/ParallelMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/concurrent/ParallelMetaheuristic.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.12.2021
  */
 public class ParallelMetaheuristic<T extends Copyable<T>> implements Metaheuristic<T>, AutoCloseable {
 	

--- a/src/main/java/org/cicirello/search/concurrent/Splittable.java
+++ b/src/main/java/org/cicirello/search/concurrent/Splittable.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -31,11 +31,9 @@ package org.cicirello.search.concurrent;
  * both safe and efficient for multiple threads to share a single copy of the Splittable object.
  *
  * @param <T> The type of object that supports splitting.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.9.2020
  */
 public interface Splittable<T extends Splittable<T>> {
 	

--- a/src/main/java/org/cicirello/search/concurrent/package-info.java
+++ b/src/main/java/org/cicirello/search/concurrent/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -22,7 +22,7 @@
  * This package includes multithreaded search implementations, as well as
  * classes and interfaces related to implementing multithreaded metaheuristics.
  * 
- * @version 10.4.2019
- * @since 1.0
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 package org.cicirello.search.concurrent;

--- a/src/main/java/org/cicirello/search/hc/package-info.java
+++ b/src/main/java/org/cicirello/search/hc/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,7 @@
  * This package includes classes and interfaces directly related to implementing
  * hill climbers.  
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.11.2019
  */
 package org.cicirello.search.hc;

--- a/src/main/java/org/cicirello/search/operators/HybridUndoableMutation.java
+++ b/src/main/java/org/cicirello/search/operators/HybridUndoableMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -33,11 +33,9 @@ import java.util.Collection;
  * the {@link #undo} method.
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.27.2020 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 public final class HybridUndoableMutation<T> implements UndoableMutationOperator<T> {
 	

--- a/src/main/java/org/cicirello/search/operators/InitializeBySimpleMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/operators/InitializeBySimpleMetaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -36,11 +36,9 @@ import org.cicirello.search.SimpleMetaheuristic;
  *
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2020
  */
 public final class InitializeBySimpleMetaheuristic<T extends Copyable<T>> implements Initializer<T> {
 	

--- a/src/main/java/org/cicirello/search/operators/Initializer.java
+++ b/src/main/java/org/cicirello/search/operators/Initializer.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -32,11 +32,9 @@ import org.cicirello.search.concurrent.Splittable;
  * this interface serve that functionality.</p>
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2020
  */
 public interface Initializer<T> extends Splittable<Initializer<T>> {
 	

--- a/src/main/java/org/cicirello/search/operators/IterableMutationOperator.java
+++ b/src/main/java/org/cicirello/search/operators/IterableMutationOperator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -63,11 +63,9 @@ package org.cicirello.search.operators;
  * </code></pre>
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.16.2019 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 public interface IterableMutationOperator<T> extends MutationOperator<T> {
 	

--- a/src/main/java/org/cicirello/search/operators/MutationIterator.java
+++ b/src/main/java/org/cicirello/search/operators/MutationIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -62,10 +62,8 @@ package org.cicirello.search.operators;
  * if (!foundOneToKeep) iter.rollback(); 
  * </code></pre>
  *
- * @since 1.0
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.4.2019
  */
 public interface MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/UndoableMutationOperator.java
+++ b/src/main/java/org/cicirello/search/operators/UndoableMutationOperator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -50,11 +50,9 @@ package org.cicirello.search.operators;
  * that do.</p>
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.27.2019
  */
 public interface UndoableMutationOperator<T> extends MutationOperator<T> {
 	

--- a/src/main/java/org/cicirello/search/operators/WeightedHybridUndoableMutation.java
+++ b/src/main/java/org/cicirello/search/operators/WeightedHybridUndoableMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -39,11 +39,9 @@ import java.util.Collection;
  * mutation operator will be used with probability 3/6 = 0.5.</p>
  *
  * @param <T> The type of object used to represent candidate solutions to the problem.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.28.2020 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 public final class WeightedHybridUndoableMutation<T> implements UndoableMutationOperator<T> {
 	

--- a/src/main/java/org/cicirello/search/operators/bits/BitFlipIterator.java
+++ b/src/main/java/org/cicirello/search/operators/bits/BitFlipIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -28,11 +28,8 @@ import org.cicirello.search.representations.BitVector;
  * Internal (package-private) class implementing an iterator over
  * all bit flips up to a specified number of flipped bits.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.27.2020 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 final class BitFlipIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/bits/BitFlipMutation.java
+++ b/src/main/java/org/cicirello/search/operators/bits/BitFlipMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -22,7 +22,6 @@ package org.cicirello.search.operators.bits;
 
 import org.cicirello.search.representations.BitVector;
 import org.cicirello.search.operators.UndoableMutationOperator;
-import org.cicirello.math.rand.RandomIndexer;
 
 /**
  * <p>This class implements Bit Flip Mutation, the mutation operator commonly used
@@ -40,16 +39,13 @@ import org.cicirello.math.rand.RandomIndexer;
  * BitVectors that guarantees that all calls to the {@link #mutate} method will change
  * the BitVector, then consider using the {@link DefiniteBitFlipMutation} class instead.</p> 
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.25.2020
  */
 public final class BitFlipMutation implements UndoableMutationOperator<BitVector> {
 	
 	private final double m;
-	private int[] flipped;
+	private BitVector bitMask;
 	
 	/**
 	 * Constructs a BitFlipMutation operator with a specified mutation rate.
@@ -69,22 +65,19 @@ public final class BitFlipMutation implements UndoableMutationOperator<BitVector
 	 */
 	private BitFlipMutation(BitFlipMutation other) {
 		m = other.m;
+		// deliberately don't copy bitMask (each instance needs to maintain its own for undo)
 	}
 	
 	@Override
 	public void mutate(BitVector c) {
-		flipped = RandomIndexer.sample(c.length(), m);
-		for (int i = 0; i < flipped.length; i++) {
-			c.flip(flipped[i]);
-		}
+		bitMask = new BitVector(c.length(), m);
+		c.xor(bitMask);
 	}
 	
 	@Override
 	public void undo(BitVector c) {
-		if (flipped != null) {
-			for (int i = 0; i < flipped.length; i++) {
-				c.flip(flipped[i]);
-			}
+		if (bitMask != null) {
+			c.xor(bitMask);
 		}
 	}
 	

--- a/src/main/java/org/cicirello/search/operators/bits/BitVectorInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/bits/BitVectorInitializer.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -28,11 +28,8 @@ import org.cicirello.search.representations.BitVector;
  * for simulated annealing and other metaheuristics.  Also used for copying such objects.
  * A BitVector is an indexable vector of bits.  
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2020
  */
 public final class BitVectorInitializer implements Initializer<BitVector> {
 	

--- a/src/main/java/org/cicirello/search/operators/bits/DefiniteBitFlipMutation.java
+++ b/src/main/java/org/cicirello/search/operators/bits/DefiniteBitFlipMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -57,11 +57,8 @@ import org.cicirello.math.rand.RandomIndexer;
  * combinations of f bits are equally likely.  The expected number of bits flipped during a single
  * call to the {@link #mutate} method is (1+B)/2.</p> 
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.27.2020
  */
 public final class DefiniteBitFlipMutation implements UndoableMutationOperator<BitVector>, IterableMutationOperator<BitVector> {
 	

--- a/src/main/java/org/cicirello/search/operators/bits/KPointCrossover.java
+++ b/src/main/java/org/cicirello/search/operators/bits/KPointCrossover.java
@@ -1,0 +1,107 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.bits;
+
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.search.operators.CrossoverOperator;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>Implementation of K-point crossover, a classic crossover operator for 
+ * BitVectors. K-point crossover is a generalization of two-point crossover.
+ * In a K-point crossover, K random cross points are chosen
+ * uniformly along the length of the bit vector parents. Both parents are cut at the
+ * K cross points, breaking the parents into multiple segments. The bits 
+ * within every other segment are then swapped between
+ * the two parents to form the two children.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class KPointCrossover implements CrossoverOperator<BitVector> {
+	
+	private final int[] indexes;
+	
+	/**
+	 * Constructs a K-point crossover operator.
+	 *
+	 * @param k The number of cross points, which must be at least 1. Although, if you want
+	 *     only a single cross point, you should instead use {@link SinglePointCrossover}; and
+	 *     likewise, if you only want 2 cross points, you should instead use {@link TwoPointCrossover}.
+	 *
+	 * @throws IllegalArgumentException if k is less than 1 
+	 */
+	public KPointCrossover(int k) {
+		if (k < 1) {
+			throw new IllegalArgumentException("Must specify at least k=1 cross points");
+		}
+		indexes = new int[k];
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if c1.length() is not equal to c2.length()
+	 * @throws IllegalArgumentException if c1.length() is less than k.
+	 */
+	@Override
+	public void cross(BitVector c1, BitVector c2) {
+		RandomIndexer.sample(c1.length(), indexes.length, indexes);
+		sort(indexes);
+		int i = 1;
+		for ( ; i < indexes.length; i+=2) {
+			BitVector.exchangeBits(c1, c2, indexes[i-1], indexes[i]-1);
+		}
+		i--;
+		if (i < indexes.length) {
+			BitVector.exchangeBits(c1, c2, indexes[i], c1.length()-1);
+		}
+	}
+	
+	@Override
+	public KPointCrossover split() {
+		// Need to construct a fresh instance.
+		// Maintains state that cannot be shared.
+		return new KPointCrossover(indexes.length);
+	}
+	
+	private void sort(int[] indexes) {
+		// Indexes should probably be small, and might be sorted or nearly sorted
+		// depending upon which sampling method Random.sample chose... e.g., for small
+		// k relative to length, the alg it chooses will return indexes sorted (though
+		// that is not part of the contract so can't assume that to be the case.
+		// 
+		// For small length, especially if sorted or nearly sorted, an insertion sort
+		// though quadratic worst case will likely be faster than an n log n sort.
+		// If sorted or nearly sorted will run in linear time. Otherwise, due to 
+		// probably short length since k is likely small, will probably be faster
+		// than mergesort due to effects of constants.
+		for (int i = 1; i < indexes.length; i++) {
+			int element = indexes[i];
+			int j = i-1;
+			while (j >= 0 && indexes[j] > element) {
+				indexes[j+1] = indexes[j];
+				j--;
+			}
+			indexes[j+1] = element;
+		}
+	}
+}

--- a/src/main/java/org/cicirello/search/operators/bits/SinglePointCrossover.java
+++ b/src/main/java/org/cicirello/search/operators/bits/SinglePointCrossover.java
@@ -1,0 +1,61 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.bits;
+
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.search.operators.CrossoverOperator;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>Implementation of single point crossover, a classic crossover operator for 
+ * BitVectors. In a single point crossover, a random cross point is chosen
+ * uniformly along the length of the bit vector parents. Both parents are cut at that
+ * point. Each child gets the bits before the cross point from one parent, and the
+ * bits after the cross point from the other parent.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class SinglePointCrossover implements CrossoverOperator<BitVector> {
+	
+	/**
+	 * Constructs a single point crossover operator.
+	 */
+	public SinglePointCrossover() {}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if c1.length() is not equal to c2.length()
+	 * @throws IllegalArgumentException if c1.length() is less than 2.
+	 */
+	@Override
+	public void cross(BitVector c1, BitVector c2) {
+		BitVector.exchangeBits(c1, c2, 0, RandomIndexer.nextInt(c1.length()-1));
+	}
+	
+	@Override
+	public SinglePointCrossover split() {
+		// Doesn't maintain any state, so safe to use with multiple threads.
+		// Just return this.
+		return this;
+	}
+}

--- a/src/main/java/org/cicirello/search/operators/bits/TwoPointCrossover.java
+++ b/src/main/java/org/cicirello/search/operators/bits/TwoPointCrossover.java
@@ -1,0 +1,70 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.bits;
+
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.search.operators.CrossoverOperator;
+import org.cicirello.math.rand.RandomIndexer;
+
+/**
+ * <p>Implementation of two-point crossover, a classic crossover operator for 
+ * BitVectors. In a two-point crossover, two random cross points are chosen
+ * uniformly along the length of the bit vector parents. Both parents are cut at the
+ * two cross points. The bits between the two cross points are then swapped between
+ * the two parents to form the two children.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class TwoPointCrossover implements CrossoverOperator<BitVector> {
+	
+	private final int[] indexes;
+	
+	/**
+	 * Constructs a two-point crossover operator.
+	 */
+	public TwoPointCrossover() {
+		indexes = new int[2];
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if c1.length() is not equal to c2.length()
+	 * @throws IllegalArgumentException if c1.length() is less than 2.
+	 */
+	@Override
+	public void cross(BitVector c1, BitVector c2) {
+		RandomIndexer.nextIntPair(c1.length(), indexes);
+		if (indexes[1] > indexes[0]) {
+			BitVector.exchangeBits(c1, c2, indexes[0], indexes[1]-1);
+		} else {
+			BitVector.exchangeBits(c1, c2, indexes[1], indexes[0]-1);
+		}
+	}
+	
+	@Override
+	public TwoPointCrossover split() {
+		// Need to construct a fresh instance.
+		// Maintains state that cannot be shared.
+		return new TwoPointCrossover();
+	}
+}

--- a/src/main/java/org/cicirello/search/operators/bits/UniformCrossover.java
+++ b/src/main/java/org/cicirello/search/operators/bits/UniformCrossover.java
@@ -1,0 +1,78 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.bits;
+
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.search.operators.CrossoverOperator;
+
+/**
+ * <p>Implementation of uniform crossover, a classic crossover operator for 
+ * BitVectors. In uniform crossover, instead of a fixed number of cross points,
+ * the crossover operator is controlled by a parameter, p, that is the probability
+ * that a bit is exchanged between the two parents. If the BitVectors are N bits in
+ * length, then N independent random decisions are made regarding whether to exchange each
+ * bit between the parents in forming the children. The expected number of bits
+ * exchanged between the parents during a single crossover event is thus p*N. The
+ * most common value for p=0.5, which leads to each child inheriting on average half
+ * of the bits from each of the two parents.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class UniformCrossover implements CrossoverOperator<BitVector> {
+	
+	private final double p;
+	
+	/**
+	 * Constructs a uniform crossover operator with a probability of 
+	 * exchanging each bit of p=0.5.
+	 */
+	public UniformCrossover() {
+		p = 0.5;
+	}
+	
+	/**
+	 * Constructs a uniform crossover operator.
+	 *
+	 * @param p The per-bit probability of exchanging each bit between the parents
+	 * in forming the children. The expected number of bits exchanged during a single
+	 * call to {@link #cross} is thus p*N, where N is the length of the BitVector.
+	 */
+	public UniformCrossover(double p) {
+		this.p = p <= 0.0 ? 0.0 : (p >= 1.0 ? 1.0 : p);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if c1.length() is not equal to c2.length()
+	 */
+	@Override
+	public void cross(BitVector c1, BitVector c2) {
+		BitVector.exchangeBits(c1, c2, new BitVector(c1.length(), p));
+	}
+	
+	@Override
+	public UniformCrossover split() {
+		// Maintains no mutable state, so just return this.
+		return this;
+	}
+}

--- a/src/main/java/org/cicirello/search/operators/bits/package-info.java
+++ b/src/main/java/org/cicirello/search/operators/bits/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,7 @@
  * This package includes classes that implement operators that create, mutate, etc,
  * BitVectors.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.24.2020
  */
 package org.cicirello.search.operators.bits;

--- a/src/main/java/org/cicirello/search/operators/integers/package-info.java
+++ b/src/main/java/org/cicirello/search/operators/integers/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,7 @@
  * This package includes classes that implement operators that create, mutate, etc,
  * integer valued representations.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.25.2019
  */
 package org.cicirello.search.operators.integers;

--- a/src/main/java/org/cicirello/search/operators/package-info.java
+++ b/src/main/java/org/cicirello/search/operators/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -24,10 +24,8 @@
  * required by simulated annealing and other metaheuristics, such as 
  * mutation operators, along with
  * other related classes and interfaces. 
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.21.2019
  */
 package org.cicirello.search.operators;

--- a/src/main/java/org/cicirello/search/operators/permutations/BlockInterchangeMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/BlockInterchangeMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -48,11 +48,8 @@ import org.cicirello.math.rand.RandomIndexer;
  * movement of every permutation element.  On average, approximately 0.6 n elements
  * are moved by this mutation operator.</p>  
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.11.2019
  */
 public class BlockInterchangeMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/BlockMoveMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/BlockMoveMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -47,11 +47,8 @@ import org.cicirello.math.rand.RandomIndexer;
  * is at one end of the permutation, and reinserted at the opposite end, which causes all n permutation
  * elements to move.  On average, a block move affects n/2 element locations.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.9.2019
  */
 public class BlockMoveMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/InsertionMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/InsertionMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -39,11 +39,8 @@ import org.cicirello.math.rand.RandomIndexer;
  * elements to move one position each.  On average, an insertion mutation moves approximately 
  * n/3 elements.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
  */
 public class InsertionMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 

--- a/src/main/java/org/cicirello/search/operators/permutations/PermutationInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/PermutationInitializer.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -37,11 +37,8 @@ import org.cicirello.permutations.Permutation;
  * metaheuristics (e.g., hill climbers and simulated annealers often 
  * begin at a random solution).</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2020
  */
 public final class PermutationInitializer implements Initializer<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/ReversalIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/ReversalIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -27,11 +27,8 @@ import org.cicirello.permutations.Permutation;
  * Internal (package-private) class implementing an iterator over
  * all reversals.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 final class ReversalIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/ReversalMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/ReversalMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -41,7 +41,6 @@ import org.cicirello.math.rand.RandomIndexer;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.14.2021
  */
 public class ReversalMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/RotationIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/RotationIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -29,7 +29,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 3.22.2021 
  */
 final class RotationIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/RotationMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/RotationMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -42,7 +42,6 @@ import org.cicirello.math.rand.RandomIndexer;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 3.22.2021
  */
 public final class RotationMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/SwapIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/SwapIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -27,11 +27,8 @@ import org.cicirello.permutations.Permutation;
  * Internal (package-private) class implementing an iterator over
  * all swaps.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 final class SwapIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/SwapMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/SwapMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -39,7 +39,6 @@ import org.cicirello.math.rand.RandomIndexer;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.15.2021
  */
 public class SwapMutation implements UndoableMutationOperator<Permutation>, IterableMutationOperator<Permutation> {
 

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedInsertionIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedInsertionIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -29,7 +29,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.12.2021 
  */
 final class WindowLimitedInsertionIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedInsertionMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedInsertionMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -43,11 +43,8 @@ import org.cicirello.permutations.Permutation;
  * in Proceedings of the 8th International Conference on Bioinspired Information and 
  * Communications Technologies, pages 28–35, December 2014.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
  */
 public final class WindowLimitedInsertionMutation extends InsertionMutation {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedReversalIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedReversalIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -27,11 +27,8 @@ import org.cicirello.permutations.Permutation;
  * Internal (package-private) class implementing an iterator over
  * all window limited reversals.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 final class WindowLimitedReversalIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedReversalMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedReversalMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -43,11 +43,8 @@ import org.cicirello.permutations.Permutation;
  * in Proceedings of the 8th International Conference on Bioinspired Information and 
  * Communications Technologies, pages 28–35, December 2014.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
  */
 public final class WindowLimitedReversalMutation extends ReversalMutation {
 

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedSwapIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedSwapIterator.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -27,11 +27,8 @@ import org.cicirello.permutations.Permutation;
  * Internal (package-private) class implementing an iterator over
  * all window limited swaps.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
- * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 final class WindowLimitedSwapIterator implements MutationIterator {
 	

--- a/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedSwapMutation.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/WindowLimitedSwapMutation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -41,11 +41,8 @@ import org.cicirello.search.operators.MutationIterator;
  * in Proceedings of the 8th International Conference on Bioinspired Information and 
  * Communications Technologies, pages 28–35, December 2014.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.7.2019
  */
 public final class WindowLimitedSwapMutation extends SwapMutation {
 

--- a/src/main/java/org/cicirello/search/operators/permutations/package-info.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -27,10 +27,7 @@
  * More information on the JPT can be found at the website for that library:
  * <a href=https://jpt.cicirello.org/ target=_top>JPT</a>.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.4.2019
  */
 package org.cicirello.search.operators.permutations;

--- a/src/main/java/org/cicirello/search/operators/reals/package-info.java
+++ b/src/main/java/org/cicirello/search/operators/reals/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -25,10 +25,7 @@
  * such as is required to solve function optimization
  * problems using simulated annealing or other metaheuristics.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.25.2019
  */
 package org.cicirello.search.operators.reals;

--- a/src/main/java/org/cicirello/search/package-info.java
+++ b/src/main/java/org/cicirello/search/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,8 @@
  * This package includes classes and interfaces related to implementing
  * metaheuristic search algorithms in general, rather than specific to a particular
  * metaheuristic.
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.30.2019
  */
 package org.cicirello.search;

--- a/src/main/java/org/cicirello/search/problems/PermutationInAHaystack.java
+++ b/src/main/java/org/cicirello/search/problems/PermutationInAHaystack.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -52,11 +52,8 @@ import org.cicirello.permutations.distance.PermutationDistanceMeasurer;
  * Permutation in a Haystack Problem and the Calculus of Search Landscapes,"</a> 
  * IEEE Transactions on Evolutionary Computation, 20(3):434-446, June 2016.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.11.2020
  */
 public final class PermutationInAHaystack implements IntegerCostOptimizationProblem<Permutation> {
 	

--- a/src/main/java/org/cicirello/search/problems/package-info.java
+++ b/src/main/java/org/cicirello/search/problems/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,8 @@
  * Package of classes and interfaces related to representing
  * computational problems, as well as classes implementing
  * a variety of specific computational problems. 
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.29.2020
  */
 package org.cicirello.search.problems;

--- a/src/main/java/org/cicirello/search/problems/scheduling/package-info.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,8 @@
  * Package of classes and interfaces related to representing
  * and solving scheduling problems, which includes implementations
  * of constructive heuristics for scheduling problems. 
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.13.2020
  */
 package org.cicirello.search.problems.scheduling;

--- a/src/main/java/org/cicirello/search/problems/tsp/package-info.java
+++ b/src/main/java/org/cicirello/search/problems/tsp/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 

--- a/src/main/java/org/cicirello/search/representations/BitVector.java
+++ b/src/main/java/org/cicirello/search/representations/BitVector.java
@@ -110,6 +110,7 @@ public final class BitVector implements Copyable<BitVector> {
 	 * @param lastIndex The last index of the sequence to exchange, inclusive.
 	 *
 	 * @throws IndexOutOfBoundsException if either index is negative, or if either index &ge; length()
+	 * @throws IllegalArgumentException if b1.length() is not equal to b2.length()
 	 */
 	public static void exchangeBitSequence(BitVector b1, BitVector b2, int firstIndex, int lastIndex) {
 		if (firstIndex > lastIndex) {
@@ -117,7 +118,10 @@ public final class BitVector implements Copyable<BitVector> {
 			firstIndex = lastIndex;
 			lastIndex = temp;
 		}
-		if (firstIndex < 0 || lastIndex >= b1.bitLength || lastIndex >= b2.bitLength) {
+		if (b1.bitLength != b2.bitLength) {
+			throw new IllegalArgumentException("BitVectors must be same length");
+		}
+		if (firstIndex < 0 || lastIndex >= b1.bitLength) {
 			throw new IndexOutOfBoundsException("index(es) is(are) not in the bounds of the BitVector");
 		}
 		int firstBlock = firstIndex >> 5;

--- a/src/main/java/org/cicirello/search/representations/BitVector.java
+++ b/src/main/java/org/cicirello/search/representations/BitVector.java
@@ -112,7 +112,7 @@ public final class BitVector implements Copyable<BitVector> {
 	 * @throws IndexOutOfBoundsException if either index is negative, or if either index &ge; length()
 	 * @throws IllegalArgumentException if b1.length() is not equal to b2.length()
 	 */
-	public static void exchangeBitSequence(BitVector b1, BitVector b2, int firstIndex, int lastIndex) {
+	public static void exchangeBits(BitVector b1, BitVector b2, int firstIndex, int lastIndex) {
 		if (firstIndex > lastIndex) {
 			int temp = firstIndex;
 			firstIndex = lastIndex;

--- a/src/main/java/org/cicirello/search/representations/BitVector.java
+++ b/src/main/java/org/cicirello/search/representations/BitVector.java
@@ -538,6 +538,10 @@ public final class BitVector implements Copyable<BitVector> {
 		return h;
 	}
 	
+	/**
+	 * Returns a String representation of the BitVector.
+	 * @return a String representation of the BitVector.
+	 */
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(bitLength);

--- a/src/main/java/org/cicirello/search/representations/BitVector.java
+++ b/src/main/java/org/cicirello/search/representations/BitVector.java
@@ -109,8 +109,8 @@ public final class BitVector implements Copyable<BitVector> {
 	 * @param firstIndex The first index of the sequence to exchange, inclusive.
 	 * @param lastIndex The last index of the sequence to exchange, inclusive.
 	 *
-	 * @throws IndexOutOfBoundsException if either index is negative, or if either index &ge; length()
 	 * @throws IllegalArgumentException if b1.length() is not equal to b2.length()
+	 * @throws IndexOutOfBoundsException if either index is negative, or if either index &ge; length()
 	 */
 	public static void exchangeBits(BitVector b1, BitVector b2, int firstIndex, int lastIndex) {
 		if (firstIndex > lastIndex) {
@@ -159,6 +159,27 @@ public final class BitVector implements Copyable<BitVector> {
 				b1.bits[i] = b2.bits[i];
 				b2.bits[i] = temp;
 			}
+		}
+	}
+	
+	/**
+	 * Exchanges a selection of bits between two BitVectors, where the bits to exchange are
+	 * indicated by a bit mask, also represented by a BitVector.
+	 *
+	 * @param b1 The first BitVector.
+	 * @param b2 The second BitVector.
+	 * @param mask A bit mask indicating which bit positions to exchange. Specifically, if mask.getBit(i)
+	 *     is a 1, then b1 and b2 will trade the bits in position i between each other, and otherwise they
+	 *     won't.
+	 *
+	 * @throws IllegalArgumentException if the lengths of b1, b2, and mask, are not all the same.
+	 */
+	public static void exchangeBits(BitVector b1, BitVector b2, BitVector mask) {
+		if (b1.bitLength != mask.bitLength || b2.bitLength != mask.bitLength) {
+			throw new IllegalArgumentException("BitVectors must be same length");
+		}
+		for (int i = 0; i < mask.bits.length; i++) {
+			partialBlockSwap(b1, b2, i, ~mask.bits[i], mask.bits[i]);
 		}
 	}
 	

--- a/src/main/java/org/cicirello/search/representations/IntegerValued.java
+++ b/src/main/java/org/cicirello/search/representations/IntegerValued.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -26,11 +26,8 @@ package org.cicirello.search.representations;
  * Classes implementing this interface may be applicable for
  * function optimization problems.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.5.2020
  */
 public interface IntegerValued {
 	

--- a/src/main/java/org/cicirello/search/representations/RealValued.java
+++ b/src/main/java/org/cicirello/search/representations/RealValued.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -28,11 +28,8 @@ package org.cicirello.search.representations;
  * Classes implementing this interface may be applicable for
  * real-valued function optimization problems.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.5.2020
  */
 public interface RealValued {
 	

--- a/src/main/java/org/cicirello/search/representations/package-info.java
+++ b/src/main/java/org/cicirello/search/representations/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -21,10 +21,8 @@
  
 /**
  * This package includes classes related to representing solutions to optimization problems. 
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 3.3.2020
  */
 package org.cicirello.search.representations;

--- a/src/main/java/org/cicirello/search/restarts/Multistarter.java
+++ b/src/main/java/org/cicirello/search/restarts/Multistarter.java
@@ -37,7 +37,6 @@ import org.cicirello.util.Copyable;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.12.2021
  */
 public class Multistarter<T extends Copyable<T>> implements Metaheuristic<T> {
 	

--- a/src/main/java/org/cicirello/search/restarts/ParallelVariableAnnealingLength.java
+++ b/src/main/java/org/cicirello/search/restarts/ParallelVariableAnnealingLength.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -104,11 +104,8 @@ import java.util.ArrayList;
  * pages 2-10. AAAI Press, June 2017.</p>
  *
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.29.2020
  */
 public final class ParallelVariableAnnealingLength implements RestartSchedule {
 	

--- a/src/main/java/org/cicirello/search/restarts/RestartSchedule.java
+++ b/src/main/java/org/cicirello/search/restarts/RestartSchedule.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -29,11 +29,8 @@ import org.cicirello.search.concurrent.Splittable;
  * schedules that vary the run length from one run to the next in some way.
  * This interface defines the functionality of a restart schedule.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.8.2020
  */
 public interface RestartSchedule extends Splittable<RestartSchedule> {
 	

--- a/src/main/java/org/cicirello/search/restarts/package-info.java
+++ b/src/main/java/org/cicirello/search/restarts/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,7 +23,8 @@
  * This package includes classes and interfaces related to implementing multistart
  * metaheuristics (i.e., metaheuristics that periodically restart, and return the best
  * solution across a number of such restarts). 
- * @version 10.2.2019
- * @since 1.0
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 package org.cicirello.search.restarts;

--- a/src/main/java/org/cicirello/search/sa/ExponentialCooling.java
+++ b/src/main/java/org/cicirello/search/sa/ExponentialCooling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -46,11 +46,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * <p>The {@link #accept accept} methods of this class use the classic, and most common,
  * Boltzmann distribution for determining whether to accept a neighbor.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.30.2019
  */
 public final class ExponentialCooling implements AnnealingSchedule {
 	

--- a/src/main/java/org/cicirello/search/sa/LinearCooling.java
+++ b/src/main/java/org/cicirello/search/sa/LinearCooling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -45,11 +45,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * <p>The {@link #accept accept} methods of this class use the classic, and most common,
  * Boltzmann distribution for determining whether to accept a neighbor.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.23.2019
  */
 public final class LinearCooling implements AnnealingSchedule {
 	

--- a/src/main/java/org/cicirello/search/sa/LogarithmicCooling.java
+++ b/src/main/java/org/cicirello/search/sa/LogarithmicCooling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -49,11 +49,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * t<sub>k</sub> = t<sub>0</sub> / ln(k + e), where e is the base of the natural
  * logarithm.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.2.2019
  */
 public final class LogarithmicCooling implements AnnealingSchedule {
 	

--- a/src/main/java/org/cicirello/search/sa/ParameterFreeExponentialCooling.java
+++ b/src/main/java/org/cicirello/search/sa/ParameterFreeExponentialCooling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -75,11 +75,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * for setting &alpha; &le; 0.999 is to avoid any numerical issues that may arise from repeatedly multiplying
  * by a value that is very close to 1.0.</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.30.2019
  */
 public final class ParameterFreeExponentialCooling implements AnnealingSchedule {
 	

--- a/src/main/java/org/cicirello/search/sa/ParameterFreeLinearCooling.java
+++ b/src/main/java/org/cicirello/search/sa/ParameterFreeLinearCooling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -73,11 +73,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * for setting steps to a power of 2 is for efficiency in computing &Delta;t and steps (start steps at 1
  * and double until &Delta;t is in target range, very few iterations needed and usually terminates after first).</p>
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.30.2019
  */
 public final class ParameterFreeLinearCooling implements AnnealingSchedule {
 	

--- a/src/main/java/org/cicirello/search/sa/package-info.java
+++ b/src/main/java/org/cicirello/search/sa/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -23,10 +23,8 @@
  * This package includes classes and interfaces directly related to implementing
  * simulated annealing.  This includes simulated annealing itself, annealing schedules,
  * etc. 
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.16.2019
  */
 package org.cicirello.search.sa;

--- a/src/main/java/org/cicirello/search/ss/IterativeSampling.java
+++ b/src/main/java/org/cicirello/search/ss/IterativeSampling.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -42,11 +42,8 @@ import org.cicirello.search.operators.Initializer;
  *
  * @param <T> The type of object under optimization.
  *
- * @since 1.0
- *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 8.12.2020
  */
 public final class IterativeSampling<T extends Copyable<T>> extends AbstractStochasticSampler<T> {
 	

--- a/src/main/java/org/cicirello/search/ss/package-info.java
+++ b/src/main/java/org/cicirello/search/ss/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -22,10 +22,8 @@
 /**
  * This package includes classes and interfaces directly related to implementing
  * stochastic sampling algorithms.   
- * @since 1.0
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.27.2020
  */
 package org.cicirello.search.ss;

--- a/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
@@ -1,0 +1,63 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.bits;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+import org.cicirello.search.representations.BitVector;
+
+public class BitVectorCrossoverTests {
+	
+	@Test
+	public void testSinglePoint() {
+		SinglePointCrossover crossover = new SinglePointCrossover();
+		for (int n = 2; n <= 64; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertEquals(1, countNumberOfCrossPoints(b1));
+			assertEquals(1, countNumberOfCrossPoints(b2));
+			b2.not();
+			assertEquals(b1, b2);
+		}
+		crossover = crossover.split();
+		for (int n = 2; n <= 64; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertEquals(1, countNumberOfCrossPoints(b1));
+			assertEquals(1, countNumberOfCrossPoints(b2));
+			b2.not();
+			assertEquals(b1, b2);
+		}
+	}
+	
+	private int countNumberOfCrossPoints(BitVector b) {
+		// Assumes that parents were all 0s and all 1s
+		int count = 0;
+		for (int i = 1; i < b.length(); i++) {
+			if (b.getBit(i) != b.getBit(i-1)) {
+				count++;
+			}
+		}
+		return count;
+	}
+}

--- a/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
@@ -50,6 +50,66 @@ public class BitVectorCrossoverTests {
 		}
 	}
 	
+	@Test
+	public void testTwoPoint() {
+		TwoPointCrossover crossover = new TwoPointCrossover();
+		// if n is 2, then equivalent to a single point
+		BitVector b1 = new BitVector(2);
+		BitVector b2 = new BitVector(2, 1.0);
+		crossover.cross(b1, b2);
+		assertEquals(1, countNumberOfCrossPoints(b1));
+		assertEquals(1, countNumberOfCrossPoints(b2));
+		b2.not();
+		assertEquals(b1, b2);
+		for (int n = 4; n <= 64; n*=2) {
+			boolean foundAtLeastOne2Case = false;
+			for (int i = 0; i < 30 && !foundAtLeastOne2Case; i++) {
+				b1 = new BitVector(n);
+				b2 = new BitVector(n, 1.0);
+				crossover.cross(b1, b2);
+				int count1 = countNumberOfCrossPoints(b1);
+				int count2 = countNumberOfCrossPoints(b2);
+				assertTrue(count1 >= 1 && count1 <= 2);
+				assertTrue(count1 >= 1 && count1 <= 2);
+				assertEquals(count1, count2);
+				b2.not();
+				assertEquals(b1, b2);
+				if (count1 == 2) {
+					foundAtLeastOne2Case = true;
+				}
+			}
+			assertTrue(foundAtLeastOne2Case);
+		}
+		// if n is 2, then equivalent to a single point
+		crossover = crossover.split();
+		b1 = new BitVector(2);
+		b2 = new BitVector(2, 1.0);
+		crossover.cross(b1, b2);
+		assertEquals(1, countNumberOfCrossPoints(b1));
+		assertEquals(1, countNumberOfCrossPoints(b2));
+		b2.not();
+		assertEquals(b1, b2);
+		for (int n = 4; n <= 64; n*=2) {
+			boolean foundAtLeastOne2Case = false;
+			for (int i = 0; i < 30 && !foundAtLeastOne2Case; i++) {
+				b1 = new BitVector(n);
+				b2 = new BitVector(n, 1.0);
+				crossover.cross(b1, b2);
+				int count1 = countNumberOfCrossPoints(b1);
+				int count2 = countNumberOfCrossPoints(b2);
+				assertTrue(count1 >= 1 && count1 <= 2);
+				assertTrue(count1 >= 1 && count1 <= 2);
+				assertEquals(count1, count2);
+				b2.not();
+				assertEquals(b1, b2);
+				if (count1 == 2) {
+					foundAtLeastOne2Case = true;
+				}
+			}
+			assertTrue(foundAtLeastOne2Case);
+		}
+	}
+	
 	private int countNumberOfCrossPoints(BitVector b) {
 		// Assumes that parents were all 0s and all 1s
 		int count = 0;

--- a/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
@@ -166,6 +166,75 @@ public class BitVectorCrossoverTests {
 		);
 	}
 	
+	@Test
+	public void testUniformCrossover() {
+		UniformCrossover crossover = new UniformCrossover(0.0);
+		for (int n = 1; n <= 64; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertTrue(b2.allOnes());
+			assertTrue(b1.allZeros());
+			b2.not();
+			assertEquals(b1, b2);
+		}
+		crossover = new UniformCrossover(1.0);
+		for (int n = 1; n <= 64; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertTrue(b1.allOnes());
+			assertTrue(b2.allZeros());
+			b2.not();
+			assertEquals(b1, b2);
+		}
+		double[] rates = {0.33, 0.5, 0.66};
+		for (double p : rates) {
+			crossover = new UniformCrossover(p);
+			for (int n = 32; n <= 128; n*=2) {
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n, 1.0);
+				crossover.cross(b1, b2);
+				assertFalse(b1.allOnes());
+				assertFalse(b2.allOnes());
+				assertFalse(b1.allZeros());
+				assertFalse(b2.allZeros());
+				b2.not();
+				assertEquals(b1, b2);
+			}
+		}
+		crossover = new UniformCrossover();
+		for (int n = 32; n <= 128; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertFalse(b1.allOnes());
+			assertFalse(b2.allOnes());
+			assertFalse(b1.allZeros());
+			assertFalse(b2.allZeros());
+			b2.not();
+			assertEquals(b1, b2);
+		}
+		// test split version
+		crossover = crossover.split();
+		for (int n = 32; n <= 128; n*=2) {
+			BitVector b1 = new BitVector(n);
+			BitVector b2 = new BitVector(n, 1.0);
+			crossover.cross(b1, b2);
+			assertFalse(b1.allOnes());
+			assertFalse(b2.allOnes());
+			assertFalse(b1.allZeros());
+			assertFalse(b2.allZeros());
+			b2.not();
+			assertEquals(b1, b2);
+		}
+		final UniformCrossover crossover2 = crossover;
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> crossover2.cross(new BitVector(5), new BitVector(6))
+		);
+	}
+	
 	private int countNumberOfCrossPoints(BitVector b, int shouldStartWith) {
 		// Assumes that parents were all 0s and all 1s
 		int count = b.getBit(0) != shouldStartWith ? 1 : 0;

--- a/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
@@ -33,8 +33,8 @@ public class BitVectorCrossoverTests {
 			BitVector b1 = new BitVector(n);
 			BitVector b2 = new BitVector(n, 1.0);
 			crossover.cross(b1, b2);
-			assertEquals(1, countNumberOfCrossPoints(b1));
-			assertEquals(1, countNumberOfCrossPoints(b2));
+			assertEquals(1, countNumberOfCrossPoints(b1, 1));
+			assertEquals(1, countNumberOfCrossPoints(b2, 0));
 			b2.not();
 			assertEquals(b1, b2);
 		}
@@ -43,8 +43,8 @@ public class BitVectorCrossoverTests {
 			BitVector b1 = new BitVector(n);
 			BitVector b2 = new BitVector(n, 1.0);
 			crossover.cross(b1, b2);
-			assertEquals(1, countNumberOfCrossPoints(b1));
-			assertEquals(1, countNumberOfCrossPoints(b2));
+			assertEquals(1, countNumberOfCrossPoints(b1, 1));
+			assertEquals(1, countNumberOfCrossPoints(b2, 0));
 			b2.not();
 			assertEquals(b1, b2);
 		}
@@ -57,62 +57,50 @@ public class BitVectorCrossoverTests {
 		BitVector b1 = new BitVector(2);
 		BitVector b2 = new BitVector(2, 1.0);
 		crossover.cross(b1, b2);
-		assertEquals(1, countNumberOfCrossPoints(b1));
-		assertEquals(1, countNumberOfCrossPoints(b2));
+		assertEquals(1, countNumberOfCrossPoints(b1, 1));
+		assertEquals(1, countNumberOfCrossPoints(b2, 0));
 		b2.not();
 		assertEquals(b1, b2);
 		for (int n = 4; n <= 64; n*=2) {
-			boolean foundAtLeastOne2Case = false;
-			for (int i = 0; i < 30 && !foundAtLeastOne2Case; i++) {
+			for (int i = 0; i < 5; i++) {
 				b1 = new BitVector(n);
 				b2 = new BitVector(n, 1.0);
 				crossover.cross(b1, b2);
-				int count1 = countNumberOfCrossPoints(b1);
-				int count2 = countNumberOfCrossPoints(b2);
-				assertTrue(count1 >= 1 && count1 <= 2);
-				assertTrue(count1 >= 1 && count1 <= 2);
-				assertEquals(count1, count2);
+				int count1 = countNumberOfCrossPoints(b1, 0);
+				int count2 = countNumberOfCrossPoints(b2, 1);
+				assertEquals(2, count1);
+				assertEquals(2, count2);
 				b2.not();
 				assertEquals(b1, b2);
-				if (count1 == 2) {
-					foundAtLeastOne2Case = true;
-				}
 			}
-			assertTrue(foundAtLeastOne2Case);
 		}
 		// if n is 2, then equivalent to a single point
 		crossover = crossover.split();
 		b1 = new BitVector(2);
 		b2 = new BitVector(2, 1.0);
 		crossover.cross(b1, b2);
-		assertEquals(1, countNumberOfCrossPoints(b1));
-		assertEquals(1, countNumberOfCrossPoints(b2));
+		assertEquals(1, countNumberOfCrossPoints(b1, 1));
+		assertEquals(1, countNumberOfCrossPoints(b2, 0));
 		b2.not();
 		assertEquals(b1, b2);
 		for (int n = 4; n <= 64; n*=2) {
-			boolean foundAtLeastOne2Case = false;
-			for (int i = 0; i < 30 && !foundAtLeastOne2Case; i++) {
+			for (int i = 0; i < 5; i++) {
 				b1 = new BitVector(n);
 				b2 = new BitVector(n, 1.0);
 				crossover.cross(b1, b2);
-				int count1 = countNumberOfCrossPoints(b1);
-				int count2 = countNumberOfCrossPoints(b2);
-				assertTrue(count1 >= 1 && count1 <= 2);
-				assertTrue(count1 >= 1 && count1 <= 2);
-				assertEquals(count1, count2);
+				int count1 = countNumberOfCrossPoints(b1, 0);
+				int count2 = countNumberOfCrossPoints(b2, 1);
+				assertEquals(2, count1);
+				assertEquals(2, count2);
 				b2.not();
 				assertEquals(b1, b2);
-				if (count1 == 2) {
-					foundAtLeastOne2Case = true;
-				}
 			}
-			assertTrue(foundAtLeastOne2Case);
 		}
 	}
 	
-	private int countNumberOfCrossPoints(BitVector b) {
+	private int countNumberOfCrossPoints(BitVector b, int shouldStartWith) {
 		// Assumes that parents were all 0s and all 1s
-		int count = 0;
+		int count = b.getBit(0) != shouldStartWith ? 1 : 0;
 		for (int i = 1; i < b.length(); i++) {
 			if (b.getBit(i) != b.getBit(i-1)) {
 				count++;

--- a/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/bits/BitVectorCrossoverTests.java
@@ -48,6 +48,15 @@ public class BitVectorCrossoverTests {
 			b2.not();
 			assertEquals(b1, b2);
 		}
+		final SinglePointCrossover crossover2 = crossover;
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> crossover2.cross(new BitVector(1), new BitVector(1))
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> crossover2.cross(new BitVector(5), new BitVector(4))
+		);
 	}
 	
 	@Test
@@ -96,6 +105,65 @@ public class BitVectorCrossoverTests {
 				assertEquals(b1, b2);
 			}
 		}
+		final TwoPointCrossover crossover2 = crossover;
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> crossover2.cross(new BitVector(1), new BitVector(1))
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> crossover2.cross(new BitVector(5), new BitVector(4))
+		);
+	}
+	
+	@Test
+	public void testKPoint() {
+		for (int k = 1; k < 8; k++) {
+			KPointCrossover crossover = new KPointCrossover(k);
+			final int MAX_N = 2*k*k;
+			for (int n = k; n <= MAX_N; n*=2) {
+				for (int i = 0; i < 5; i++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n, 1.0);
+					crossover.cross(b1, b2);
+					int count1 = countNumberOfCrossPoints(b1, 0);
+					int count2 = countNumberOfCrossPoints(b2, 1);
+					assertEquals(k, count1);
+					assertEquals(k, count2);
+					b2.not();
+					assertEquals(b1, b2);
+				}
+			}
+			// test split version
+			crossover = crossover.split();
+			for (int n = k; n <= MAX_N; n*=2) {
+				for (int i = 0; i < 5; i++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n, 1.0);
+					crossover.cross(b1, b2);
+					int count1 = countNumberOfCrossPoints(b1, 0);
+					int count2 = countNumberOfCrossPoints(b2, 1);
+					assertEquals(k, count1);
+					assertEquals(k, count2);
+					b2.not();
+					assertEquals(b1, b2);
+				}
+			}
+			final KPointCrossover crossover2 = crossover;
+			final int K_PRIME = k;
+			IllegalArgumentException thrown = assertThrows( 
+				IllegalArgumentException.class,
+				() -> crossover2.cross(new BitVector(K_PRIME-1), new BitVector(K_PRIME-1))
+			);
+			thrown = assertThrows( 
+				IllegalArgumentException.class,
+				() -> crossover2.cross(new BitVector(K_PRIME+5), new BitVector(K_PRIME+4))
+			);
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new KPointCrossover(0)
+		);
 	}
 	
 	private int countNumberOfCrossPoints(BitVector b, int shouldStartWith) {

--- a/src/test/java/org/cicirello/search/representations/BitVectorTests.java
+++ b/src/test/java/org/cicirello/search/representations/BitVectorTests.java
@@ -30,6 +30,579 @@ import java.util.Arrays;
 public class BitVectorTests {
 	
 	@Test
+	public void testExchangeBitSequence_Exceptions() {
+		IndexOutOfBoundsException thrown = assertThrows( 
+			IndexOutOfBoundsException.class,
+			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), -1, 1)
+		);
+		thrown = assertThrows( 
+			IndexOutOfBoundsException.class,
+			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 1, -1)
+		);
+		thrown = assertThrows( 
+			IndexOutOfBoundsException.class,
+			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 32, 1)
+		);
+		thrown = assertThrows( 
+			IndexOutOfBoundsException.class,
+			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 1, 32)
+		);
+		IllegalArgumentException thrown2 = assertThrows( 
+			IllegalArgumentException.class,
+			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(33), 1, 1)
+		);
+	}
+	
+	@Test
+	public void testExchangeBitSequence_PartialBlocksAtEnds() {
+		// Swapped bits opposite
+		for (int n = 96; n <= 128; n+=32) {
+			// b1 0s
+			for (int i = 1; i < 32; i++) {
+				for (int j = n-32; j < n-1; j++) {				
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+			// b2 0s
+			for (int i = 1; i < 32; i++) {
+				for (int j = n-32; j < n-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 96; n <= 128; n+=32) {
+			for (int i = 1; i < 32; i++) {
+				for (int j = n-32; j < n-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 96; n <= 128; n+=32) {
+			for (int i = 1; i < 32; i++) {
+				for (int j = n-32; j < n-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_MultipleWholeBlocks() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 128; n+=32) {
+			// b1 0s
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i+63; j < n; j+= 32) {				
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+			// b2 0s
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i+63; j < n; j+= 32) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 128; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i+63; j < n; j+= 32) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 128; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i+63; j < n; j+= 32) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_SingleWholeBlock() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 96; n+=32) {
+			// b1 0s
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b2.not();
+				BitVector.exchangeBitSequence(b1, b2, i, j);
+				for (int k = 0; k < i; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+				for (int k = i; k <= j; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+				for (int k = j+1; k < i; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+			}
+			// b2 0s
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b1.not();
+				BitVector.exchangeBitSequence(b1, b2, i, j);
+				for (int k = 0; k < i; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+				for (int k = i; k <= j; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+				for (int k = j+1; k < i; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				BitVector.exchangeBitSequence(b1, b2, i, j);
+				for (int k = 0; k < n; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b1.not();
+				b2.not();
+				BitVector.exchangeBitSequence(b1, b2, i, j);
+				for (int k = 0; k < n; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_SinglePartialBlock0() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 96; n+=32) {
+			// b1 0s
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i; j < i+31; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+			// b2 0s
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i; j < i+31; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i; j < i+31; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				for (int j = i; j < i+31; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_SinglePartialBlock31() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 96; n+=32) {
+			// b1 0s
+			for (int j = 31; j < n; j+=32) {
+				for (int i = j; i > j-31; i--) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+			// b2 0s
+			for (int j = 31; j < n; j+=32) {
+				for (int i = j; i > j-31; i--) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int j = 31; j < n; j+=32) {
+				for (int i = j; i > j-31; i--) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int j = 31; j < n; j+=32) {
+				for (int i = j; i > j-31; i--) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_SinglePartialBlockMiddle() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 96; n+=32) {
+			// b1 0s
+			for (int i = 1; i < n; i+=2) {
+				int m = (i/32)*32+32;
+				for (int j = i; j < m-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+			// b2 0s
+			for (int i = 1; i < n; i+=2) {
+				int m = (i/32)*32+32;
+				for (int j = i; j < m-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+					for (int k = i; k <= j; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+					for (int k = j+1; k < i; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 1; i < n; i+=2) {
+				int m = (i/32)*32+32;
+				for (int j = i; j < m-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(0, b1.getBit(k));
+						assertEquals(0, b2.getBit(k));
+					}
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 1; i < n; i+=2) {
+				int m = (i/32)*32+32;
+				for (int j = i; j < m-1; j++) {
+					BitVector b1 = new BitVector(n);
+					BitVector b2 = new BitVector(n);
+					b1.not();
+					b2.not();
+					BitVector.exchangeBitSequence(b1, b2, i, j);
+					for (int k = 0; k < n; k++) {
+						assertEquals(1, b1.getBit(k));
+						assertEquals(1, b2.getBit(k));
+					}
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testExchangeBitSequence_SingleWholeBlock_IndexesReversed() {
+		// Swapped bits opposite
+		for (int n = 32; n <= 96; n+=32) {
+			// b1 0s
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b2.not();
+				BitVector.exchangeBitSequence(b1, b2, j, i);
+				for (int k = 0; k < i; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+				for (int k = i; k <= j; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+				for (int k = j+1; k < i; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+			}
+			// b2 0s
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b1.not();
+				BitVector.exchangeBitSequence(b1, b2, j, i);
+				for (int k = 0; k < i; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+				for (int k = i; k <= j; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+				for (int k = j+1; k < i; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+			}
+		}
+		// Swapped bits same as 0.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				BitVector.exchangeBitSequence(b1, b2, j, i);
+				for (int k = 0; k < n; k++) {
+					assertEquals(0, b1.getBit(k));
+					assertEquals(0, b2.getBit(k));
+				}
+			}
+		}
+		// Swapped bits same as 1.
+		for (int n = 32; n <= 96; n+=32) {
+			for (int i = 0; i < n; i+=32) {
+				int j = i + 31;
+				BitVector b1 = new BitVector(n);
+				BitVector b2 = new BitVector(n);
+				b1.not();
+				b2.not();
+				BitVector.exchangeBitSequence(b1, b2, j, i);
+				for (int k = 0; k < n; k++) {
+					assertEquals(1, b1.getBit(k));
+					assertEquals(1, b2.getBit(k));
+				}
+			}
+		}
+	}
+	
+	@Test
 	public void testFlipBit() {
 		for (int n = 1; n <= 64; n++) {
 			BitVector b = new BitVector(n);

--- a/src/test/java/org/cicirello/search/representations/BitVectorTests.java
+++ b/src/test/java/org/cicirello/search/representations/BitVectorTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -30,31 +30,31 @@ import java.util.Arrays;
 public class BitVectorTests {
 	
 	@Test
-	public void testExchangeBitSequence_Exceptions() {
+	public void testExchangeBits_Exceptions() {
 		IndexOutOfBoundsException thrown = assertThrows( 
 			IndexOutOfBoundsException.class,
-			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), -1, 1)
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(32), -1, 1)
 		);
 		thrown = assertThrows( 
 			IndexOutOfBoundsException.class,
-			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 1, -1)
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(32), 1, -1)
 		);
 		thrown = assertThrows( 
 			IndexOutOfBoundsException.class,
-			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 32, 1)
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(32), 32, 1)
 		);
 		thrown = assertThrows( 
 			IndexOutOfBoundsException.class,
-			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(32), 1, 32)
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(32), 1, 32)
 		);
 		IllegalArgumentException thrown2 = assertThrows( 
 			IllegalArgumentException.class,
-			() -> BitVector.exchangeBitSequence(new BitVector(32), new BitVector(33), 1, 1)
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(33), 1, 1)
 		);
 	}
 	
 	@Test
-	public void testExchangeBitSequence_PartialBlocksAtEnds() {
+	public void testExchangeBits_PartialBlocksAtEnds() {
 		// Swapped bits opposite
 		for (int n = 96; n <= 128; n+=32) {
 			// b1 0s
@@ -63,7 +63,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -84,7 +84,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b1.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -106,7 +106,7 @@ public class BitVectorTests {
 				for (int j = n-32; j < n-1; j++) {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -122,7 +122,7 @@ public class BitVectorTests {
 					BitVector b2 = new BitVector(n);
 					b1.not();
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -133,7 +133,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_MultipleWholeBlocks() {
+	public void testExchangeBits_MultipleWholeBlocks() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 128; n+=32) {
 			// b1 0s
@@ -142,7 +142,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -163,7 +163,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b1.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -185,7 +185,7 @@ public class BitVectorTests {
 				for (int j = i+63; j < n; j+= 32) {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -201,7 +201,7 @@ public class BitVectorTests {
 					BitVector b2 = new BitVector(n);
 					b1.not();
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -212,7 +212,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_SingleWholeBlock() {
+	public void testExchangeBits_SingleWholeBlock() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 96; n+=32) {
 			// b1 0s
@@ -221,7 +221,7 @@ public class BitVectorTests {
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
 				b2.not();
-				BitVector.exchangeBitSequence(b1, b2, i, j);
+				BitVector.exchangeBits(b1, b2, i, j);
 				for (int k = 0; k < i; k++) {
 					assertEquals(0, b1.getBit(k));
 					assertEquals(1, b2.getBit(k));
@@ -241,7 +241,7 @@ public class BitVectorTests {
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
 				b1.not();
-				BitVector.exchangeBitSequence(b1, b2, i, j);
+				BitVector.exchangeBits(b1, b2, i, j);
 				for (int k = 0; k < i; k++) {
 					assertEquals(1, b1.getBit(k));
 					assertEquals(0, b2.getBit(k));
@@ -262,7 +262,7 @@ public class BitVectorTests {
 				int j = i + 31;
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
-				BitVector.exchangeBitSequence(b1, b2, i, j);
+				BitVector.exchangeBits(b1, b2, i, j);
 				for (int k = 0; k < n; k++) {
 					assertEquals(0, b1.getBit(k));
 					assertEquals(0, b2.getBit(k));
@@ -277,7 +277,7 @@ public class BitVectorTests {
 				BitVector b2 = new BitVector(n);
 				b1.not();
 				b2.not();
-				BitVector.exchangeBitSequence(b1, b2, i, j);
+				BitVector.exchangeBits(b1, b2, i, j);
 				for (int k = 0; k < n; k++) {
 					assertEquals(1, b1.getBit(k));
 					assertEquals(1, b2.getBit(k));
@@ -287,7 +287,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_SinglePartialBlock0() {
+	public void testExchangeBits_SinglePartialBlock0() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 96; n+=32) {
 			// b1 0s
@@ -296,7 +296,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -317,7 +317,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b1.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -339,7 +339,7 @@ public class BitVectorTests {
 				for (int j = i; j < i+31; j++) {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -355,7 +355,7 @@ public class BitVectorTests {
 					BitVector b2 = new BitVector(n);
 					b1.not();
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -366,7 +366,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_SinglePartialBlock31() {
+	public void testExchangeBits_SinglePartialBlock31() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 96; n+=32) {
 			// b1 0s
@@ -375,7 +375,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -396,7 +396,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b1.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -418,7 +418,7 @@ public class BitVectorTests {
 				for (int i = j; i > j-31; i--) {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -434,7 +434,7 @@ public class BitVectorTests {
 					BitVector b2 = new BitVector(n);
 					b1.not();
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -445,7 +445,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_SinglePartialBlockMiddle() {
+	public void testExchangeBits_SinglePartialBlockMiddle() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 96; n+=32) {
 			// b1 0s
@@ -455,7 +455,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -477,7 +477,7 @@ public class BitVectorTests {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
 					b1.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < i; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -500,7 +500,7 @@ public class BitVectorTests {
 				for (int j = i; j < m-1; j++) {
 					BitVector b1 = new BitVector(n);
 					BitVector b2 = new BitVector(n);
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(0, b1.getBit(k));
 						assertEquals(0, b2.getBit(k));
@@ -517,7 +517,7 @@ public class BitVectorTests {
 					BitVector b2 = new BitVector(n);
 					b1.not();
 					b2.not();
-					BitVector.exchangeBitSequence(b1, b2, i, j);
+					BitVector.exchangeBits(b1, b2, i, j);
 					for (int k = 0; k < n; k++) {
 						assertEquals(1, b1.getBit(k));
 						assertEquals(1, b2.getBit(k));
@@ -528,7 +528,7 @@ public class BitVectorTests {
 	}
 	
 	@Test
-	public void testExchangeBitSequence_SingleWholeBlock_IndexesReversed() {
+	public void testExchangeBits_SingleWholeBlock_IndexesReversed() {
 		// Swapped bits opposite
 		for (int n = 32; n <= 96; n+=32) {
 			// b1 0s
@@ -537,7 +537,7 @@ public class BitVectorTests {
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
 				b2.not();
-				BitVector.exchangeBitSequence(b1, b2, j, i);
+				BitVector.exchangeBits(b1, b2, j, i);
 				for (int k = 0; k < i; k++) {
 					assertEquals(0, b1.getBit(k));
 					assertEquals(1, b2.getBit(k));
@@ -557,7 +557,7 @@ public class BitVectorTests {
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
 				b1.not();
-				BitVector.exchangeBitSequence(b1, b2, j, i);
+				BitVector.exchangeBits(b1, b2, j, i);
 				for (int k = 0; k < i; k++) {
 					assertEquals(1, b1.getBit(k));
 					assertEquals(0, b2.getBit(k));
@@ -578,7 +578,7 @@ public class BitVectorTests {
 				int j = i + 31;
 				BitVector b1 = new BitVector(n);
 				BitVector b2 = new BitVector(n);
-				BitVector.exchangeBitSequence(b1, b2, j, i);
+				BitVector.exchangeBits(b1, b2, j, i);
 				for (int k = 0; k < n; k++) {
 					assertEquals(0, b1.getBit(k));
 					assertEquals(0, b2.getBit(k));
@@ -593,7 +593,7 @@ public class BitVectorTests {
 				BitVector b2 = new BitVector(n);
 				b1.not();
 				b2.not();
-				BitVector.exchangeBitSequence(b1, b2, j, i);
+				BitVector.exchangeBits(b1, b2, j, i);
 				for (int k = 0; k < n; k++) {
 					assertEquals(1, b1.getBit(k));
 					assertEquals(1, b2.getBit(k));

--- a/src/test/java/org/cicirello/search/representations/BitVectorTests.java
+++ b/src/test/java/org/cicirello/search/representations/BitVectorTests.java
@@ -51,6 +51,35 @@ public class BitVectorTests {
 			IllegalArgumentException.class,
 			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(33), 1, 1)
 		);
+		thrown2 = assertThrows( 
+			IllegalArgumentException.class,
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(32), new BitVector(31))
+		);
+		thrown2 = assertThrows( 
+			IllegalArgumentException.class,
+			() -> BitVector.exchangeBits(new BitVector(32), new BitVector(31), new BitVector(32))
+		);
+		thrown2 = assertThrows( 
+			IllegalArgumentException.class,
+			() -> BitVector.exchangeBits(new BitVector(31), new BitVector(32), new BitVector(32))
+		);
+	}
+	
+	@Test
+	public void testExchangeBitsViaMask() {
+		int[] maskBits = { 0xffffffff, 0x00000000, 0xff00ff00, 0x00ff00ff, 0x00ff00ff, 0xff00ff00, 0xff00ff00, 0x00ff00ff };
+		int[] bits1 =    { 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xff00ff00, 0x00ff00ff, 0xff00ff00, 0x00ff00ff };
+		int[] bits2 =    { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x00ff00ff, 0xff00ff00, 0x00ff00ff, 0xff00ff00 };
+		int[] expected1 = {0xffffffff, 0x00000000, 0xff00ff00, 0x00ff00ff, 0xffffffff, 0xffffffff, 0x00000000, 0x00000000 };
+		int[] expected2 = {0x00000000, 0xffffffff, 0x00ff00ff, 0xff00ff00, 0x00000000, 0x00000000, 0xffffffff, 0xffffffff };
+		BitVector b1 = new BitVector(bits1.length*32, bits1);
+		BitVector b2 = new BitVector(bits2.length*32, bits2);
+		BitVector bMask = new BitVector(maskBits.length*32, maskBits);
+		BitVector bExpect1 = new BitVector(expected1.length*32, expected1);
+		BitVector bExpect2 = new BitVector(expected2.length*32, expected2);
+		BitVector.exchangeBits(b1, b2, bMask);
+		assertEquals(bExpect1, b1);
+		assertEquals(bExpect2, b2);
 	}
 	
 	@Test

--- a/src/test/java/org/cicirello/search/representations/BitVectorTests.java
+++ b/src/test/java/org/cicirello/search/representations/BitVectorTests.java
@@ -839,6 +839,76 @@ public class BitVectorTests {
 	}
 	
 	@Test
+	public void testConstructorBitMask() {
+		// p = 0.0 case
+		for (int n = 0; n <= 64; n++) {
+			BitVector b = new BitVector(n, 0.0);
+			assertEquals(n, b.length());
+			assertEquals(0, b.countOnes());
+			assertEquals(n, b.countZeros());
+			for (int i = 0; i < n; i++) {
+				assertEquals(0, b.getBit(i));
+				assertFalse(b.isOne(i));
+				assertTrue(b.isZero(i));
+			}
+			if (n > 0) {
+				for (int i = 0; i <= (n-1)/32; i++) {
+					assertEquals("get32("+i+") with n="+n, 0, b.get32(i));
+				}
+			}
+			BitVector b2 = b.copy();
+			assertTrue(b != b2);
+			assertEquals(b, b2);
+			assertEquals(b.hashCode(), b2.hashCode());
+		}
+		// p = 1.0 case
+		for (int n = 0; n <= 64; n++) {
+			BitVector b = new BitVector(n, 1.0);
+			assertEquals(n, b.length());
+			assertEquals(n, b.countOnes());
+			assertEquals(0, b.countZeros());
+			for (int i = 0; i < n; i++) {
+				assertEquals(1, b.getBit(i));
+				assertTrue(b.isOne(i));
+				assertFalse(b.isZero(i));
+			}
+			if (n > 0) {
+				for (int i = 0; i <= (n-1)/32 - 1; i++) {
+					assertEquals("get32("+i+") with n="+n, 0xffffffff, b.get32(i));
+				}
+				int i = (n-1)/32;
+				assertEquals("get32("+i+") with n="+n, 0xffffffff >>> (32 - (n & 0x1f)), b.get32(i));
+			}
+			BitVector b2 = b.copy();
+			assertTrue(b != b2);
+			assertEquals(b, b2);
+			assertEquals(b.hashCode(), b2.hashCode());
+		}
+		// p = 0.25, 0.5, 0.75 cases
+		double[] pCases = {0.5, 0.25, 0.75};
+		for (double p : pCases) {
+			for (int n = 0; n <= 64; n++) {
+				BitVector b = new BitVector(n, p);
+				assertEquals(n, b.length());
+				assertEquals(n, b.countZeros() + b.countOnes());
+				for (int i = 0; i < n; i++) {
+					int bit = b.getBit(i);
+					assertTrue(bit == 0 || bit == 1);
+					assertNotEquals(b.isOne(i), b.isZero(i));
+				}
+				BitVector b2 = b.copy();
+				assertEquals(n, b2.length());
+				assertTrue(b != b2);
+				assertEquals(b, b2);
+				assertEquals(b.hashCode(), b2.hashCode());
+				for (int i = 0; i < n; i++) {
+					assertEquals(b.getBit(i), b2.getBit(i));
+				}
+			}
+		}
+	}
+	
+	@Test
 	public void testConstructorRandom() {
 		for (int n = 0; n <= 64; n++) {
 			BitVector b = new BitVector(n, true);
@@ -1542,6 +1612,10 @@ public class BitVectorTests {
 		thrown = assertThrows( 
 			IllegalArgumentException.class,
 			() -> new BitVector(-1, new int[1])
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new BitVector(-1, 0.5)
 		);
 		thrown = assertThrows( 
 			IllegalArgumentException.class,


### PR DESCRIPTION
## Summary
Added crossover operators for BitVectors: single-point, two-point, k-point, and uniform. Also added enhancements to the BitVector class itself, related to implementing these crossover operators, including constructor for generating random bit masks, and methods for exchanging bits between two BitVectors.

## Closing Issues
Closes #332 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
