### PR TITLE
Refactored the new evolutionary algorithm classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   users as the GenerationalEvolutionaryAlgorithm was just introduced. For this using it
   simply use the new GenerationalMutationOnlyEvolutionaryAlgorithm class where you will
   find all the same constructors and methods necessary for mutation-only EAs.
+* All methods/constructors that were previously deprecated in earlier releases have 
+  now been removed, including:
+  * The following deprecated methods of the ProgressTracker class have been removed:
+    * `update(int, T)` in favor of using `update(int, T, boolean)`.
+    * `update(double, T)` in favor of using `update(double, T, boolean)`.
+    * `setFoundBest()` in favor of using either `update(int, T, boolean)` 
+      or `update(double, T, boolean)`.
+  * The following deprecated constructors of the SolutionCostPair class have been removed:
+    * `SolutionCostPair(T, int)` in favor of using `SolutionCostPair(T, int, boolean)`
+    * `SolutionCostPair(T, double)` in favor of using `SolutionCostPair(T, double, boolean)`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2021-12-23
 
+### BREAKING CHANGES
+* Next release will be 4.0.0 due to breaking changes.
+
 ### Added
+* Added GenerationalMutationOnlyEvolutionaryAlgorithm, moving the mutation-only EA
+  functionality into this new class from the existing GenerationalEvolutionaryAlgorithm
+  class.
 
 ### Changed
 * Refactored evolutionary algorithm classes to improve maintainability, and ease
@@ -15,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+* Removed all mutation-only EA functionality from the GenerationalEvolutionaryAlgorithm,
+  moving that functionality into the new GenerationalMutationOnlyEvolutionaryAlgorithm. This
+  was done for maintainability. It is a breaking-change, although it should affect minimal
+  users as the GenerationalEvolutionaryAlgorithm was just introduced. For this using it
+  simply use the new GenerationalMutationOnlyEvolutionaryAlgorithm class where you will
+  find all the same constructors and methods necessary for mutation-only EAs.
 
 ### Fixed
 
@@ -37,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Generational with mutation-only (no crossover).
     * Generational, parents replaced by children, with mutually exclusive crossover and mutation (i.e.,
       no child is result of both crossover and mutation).
-  * Subclasses of GenerationalEvolutionaryAlgorithms for Genetic Algorithm specific cases for convenience
+  * Subclasses of GenerationalEvolutionaryAlgorithm for Genetic Algorithm specific cases for convenience
     when optimizing BitVectors, including:
     * GeneticAlgorithm: a standard generational GA with bit flip mutation, and choice of crossover operator
       and selection operator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-12-21
+## [Unreleased] - 2021-12-23
 
 ### Added
 
 ### Changed
+* Refactored evolutionary algorithm classes to improve maintainability, and ease
+  integration of planned future functionality.
 
 ### Deprecated
 

--- a/src/main/java/org/cicirello/search/ProgressTracker.java
+++ b/src/main/java/org/cicirello/search/ProgressTracker.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -31,7 +31,6 @@ import org.cicirello.util.Copyable;
  * All other methods are non-blocking.
  *
  * @param <T> The type of object the search is optimizing.
- *
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
@@ -65,56 +64,6 @@ public final class ProgressTracker<T extends Copyable<T>> {
 		 * stop = false;
 		 * containsIntCost = false;
 		 */
-	}
-	
-	/**
-	 * Updates the best solution contained in this progress tracker.
-	 * The update takes place only if the new solution has lower cost than
-	 * the current best cost solution stored in the progress tracker.  This method
-	 * is thread-safe.  However, it uses synchronization for thread-safety, so
-	 * it is strongly suggested that in multithreaded search implementations that
-	 * you reserve calls to this method for when the search believes it has likely found 
-	 * a better solution than all currently running threads.  Although in theory the 
-	 * functionality of this class is such that it can be used as the sole means of a
-	 * search algorithm keeping track of the best found solution.  If multiple
-	 * parallel runs attempt to share this object for that purpose, significant blocking
-	 * may occur.  You may consider using the nonblocking {@link #getCost} method
-	 * first.
-	 * @param cost The cost of the solution.
-	 * @param solution The new solution.
-	 * @return The cost of the best solution found.  This may or may not be equal
-	 * to the cost passed as a parameter.  If the returned value is less than cost, then
-	 * that means the best solution was previously updated by this or another thread.
-	 * @deprecated Use {@link #update(int, Copyable, boolean)} instead.
-	 */
-	@Deprecated
-	public int update(int cost, T solution) {
-		return update(cost, solution, false);
-	}
-	
-	/**
-	 * Updates the best solution contained in this progress tracker.
-	 * The update takes place only if the new solution has lower cost than
-	 * the current best cost solution stored in the progress tracker.  This method
-	 * is thread-safe.  However, it uses synchronization for thread-safety, so
-	 * it is strongly suggested that in multithreaded search implementations that
-	 * you reserve calls to this method for when the search believes it has likely found 
-	 * a better solution than all currently running threads.  Although in theory the 
-	 * functionality of this class is such that it can be used as the sole means of a
-	 * search algorithm keeping track of the best found solution.  If multiple
-	 * parallel runs attempt to share this object for that purpose, significant blocking
-	 * may occur.  You may consider using the nonblocking {@link #getCostDouble} method
-	 * first.
-	 * @param cost The cost of the solution.
-	 * @param solution The new solution.
-	 * @return The cost of the best solution found.  This may or may not be equal
-	 * to the cost passed as a parameter.  If the returned value is less than cost, then
-	 * that means the best solution was previously updated by this or another thread.
-	 * @deprecated Use {@link #update(double, Copyable, boolean)} instead.
-	 */
-	@Deprecated
-	public double update(double cost, T solution) {
-		return update(cost, solution, false);
 	}
 	
 	/**
@@ -266,19 +215,7 @@ public final class ProgressTracker<T extends Copyable<T>> {
 	public long elapsed() {
 		return when - origin;
 	}
-	
-	/**
-	 * Record that the best solution contained in the ProgressTracker is the
-	 * best possible solution to the problem.
-	 * @deprecated Use {@link #update(int, Copyable, boolean)} or
-	 * {@link #update(double, Copyable, boolean)} instead to set the 
-	 * foundBest flag when the solution is updated.
-	 */
-	@Deprecated
-	public void setFoundBest() {
-		foundBest = true;
-	}
-	
+		
 	/**
 	 * Check whether the solution contained in the ProgressTracker has been marked
 	 * as the best possible solution.

--- a/src/main/java/org/cicirello/search/SolutionCostPair.java
+++ b/src/main/java/org/cicirello/search/SolutionCostPair.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -64,29 +64,7 @@ public final class SolutionCostPair<T extends Copyable<T>> implements Comparable
 		containsIntCost = false;
 		this.isKnownOptimal = isKnownOptimal;
 	}
-	
-	/**
-	 * Constructs a SolutionCostPair with integer cost.
-	 * @param solution The solution.
-	 * @param cost The cost of the solution.
-	 * @deprecated Use {@link #SolutionCostPair(Copyable, int, boolean)} instead.
-	 */
-	@Deprecated
-	public SolutionCostPair(T solution, int cost) {			
-		this(solution, cost, false);
-	}
-	
-	/**
-	 * Constructs a SolutionCostPair with integer cost.
-	 * @param solution The solution.
-	 * @param cost The cost of the solution.
-	 * @deprecated Use {@link #SolutionCostPair(Copyable, double, boolean)} instead.
-	 */
-	@Deprecated
-	public SolutionCostPair(T solution, double cost) {			
-		this(solution, cost, false);
-	}
-	
+		
 	/**
 	 * Gets the cost contained in this solution cost pair as an int.
 	 * Behavior is undefined if costs are floating-point values.

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -1,0 +1,152 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+import org.cicirello.util.Copyable;
+import org.cicirello.search.ReoptimizableMetaheuristic;
+import org.cicirello.search.SolutionCostPair;
+import org.cicirello.search.ProgressTracker;
+import org.cicirello.search.problems.Problem;
+
+/**
+ * Abstract base class for EA implementations.
+ *
+ * @param <T> The type of object under optimization.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>> implements ReoptimizableMetaheuristic<T> {
+	
+	private final Population<T> pop;
+	private final Problem<T> problem;
+	private long numFitnessEvals;
+	
+	/*
+	 * Internal constructor for use by subclasses in same package.
+	 * Initializes the base class. 
+	 */
+	AbstractEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
+		this.pop = pop;
+		this.problem = problem;
+	}
+	
+	/*
+	 * Internal constructor for use by split method.
+	 * package private so subclasses in same package can use it for initialization for their own split methods.
+	 */
+	AbstractEvolutionaryAlgorithm(AbstractEvolutionaryAlgorithm<T> other) {
+		// Must be split
+		pop = other.pop.split();
+		
+		// Threadsafe so just copy reference or values
+		problem = other.problem;
+		
+		// Each instance must maintain its own count of evals.
+		numFitnessEvals = 0;
+	}
+	
+	/**
+	 * Runs the evolutionary algorithm beginning from a randomly generated population. If this 
+	 * method is called multiple times, each call begins at a new randomly generated population.
+	 *
+	 * @param numGenerations The number of generations to run.
+	 *
+	 * @return The best solution found during this set of generations, which may or may not be the
+	 * same as the solution contained in the {@link ProgressTracker}, which contains the best across all
+	 * calls to optimize as well as {@link #reoptimize}. Returns null if the run did not execute, such 
+	 * as if the ProgressTracker already contains the theoretical best solution.
+	 */
+	@Override
+	public final SolutionCostPair<T> optimize(int numGenerations) {
+		if (pop.evolutionIsPaused()) return null;
+		pop.init();
+		pop.initOperators(numGenerations);
+		numFitnessEvals = numFitnessEvals + pop.size();
+		internalOptimize(numGenerations);
+		return pop.getMostFit();
+	}
+	
+	/**
+	 * Runs the evolutionary algorithm continuing from the final population from the most recent call
+	 * to either {@link #optimize} or {@link #reoptimize}, or from a random population if this is the first
+	 * call to either method. 
+	 *
+	 * @param numGenerations The number of generations to run.
+	 *
+	 * @return The best solution found during this set of generations, which may or may not be the
+	 * same as the solution contained in the {@link ProgressTracker}, which contains the best across all
+	 * calls to optimize as well as {@link #optimize}. Returns null if the run did not execute, such 
+	 * as if the ProgressTracker already contains the theoretical best solution.
+	 */
+	@Override
+	public final SolutionCostPair<T> reoptimize(int numGenerations) {
+		if (pop.evolutionIsPaused()) return null;
+		pop.initOperators(numGenerations);
+		internalOptimize(numGenerations);
+		return pop.getMostFit();
+	}
+	
+	@Override
+	public final ProgressTracker<T> getProgressTracker() {
+		return pop.getProgressTracker();
+	}
+	
+	@Override
+	public final void setProgressTracker(ProgressTracker<T> tracker) {
+		pop.setProgressTracker(tracker);
+	}
+	
+	@Override
+	public final Problem<T> getProblem() {
+		return problem;
+	}
+	
+	/**
+	 * Gets the total run length in number of fitness evaluations. This is the total run length across all 
+	 * calls to {@link #optimize} and {@link #reoptimize}. This may differ from what may be expected 
+	 * based on run lengths. For example, the search terminates if it finds the theoretical best 
+	 * solution, and also immediately returns if a prior call found the theoretical best. In such 
+	 * cases, the total run length may be less than the requested run length.
+	 *
+	 * @return The total number of generations completed across all calls to {@link #optimize} and {@link #reoptimize}.
+	 */
+	@Override
+	public long getTotalRunLength() {
+		return numFitnessEvals;
+	}
+	
+	private void internalOptimize(int numGenerations) {
+		for (int i = 0; i < numGenerations && !pop.evolutionIsPaused(); i++) {
+			numFitnessEvals = numFitnessEvals + oneGeneration(pop);
+		}
+	}
+	
+	/**
+	 * Logic for single generation.
+	 * @param pop The population.
+	 * @return number of fitness evaluations during this generation.
+	 */
+	abstract int oneGeneration(Population<T> pop);
+	
+	@Override
+	public abstract AbstractEvolutionaryAlgorithm<T> split();
+}

--- a/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
@@ -41,7 +41,7 @@ import org.cicirello.math.rand.RandomVariates;
  * {@link MutationOperator}, and {@link SelectionOperator} classes to one of the
  * constructors.</p>
  *
- * <p>This class supports a variety of evolutionary algorithm models, depending
+ * <p>This class supports multiple evolutionary algorithm models, depending
  * upon the constructor you use, including:</p>
  * <ul>
  * <li>The typical generational model using both crossover and mutation, controlled by
@@ -52,12 +52,9 @@ import org.cicirello.math.rand.RandomVariates;
  * controlled by a crossover rate and a mutation rate, but such that each child is the
  * result of crossover, or mutation, or a simply copy of a parent, but never the result
  * of both crossover and mutation.</li>
- * <li>A generational mutation-only evolutionary algorithm.</li>
  * </ul>
- * <p>Note that it does not include a constructor dedicated to a crossover-only case
- * since it would be rare (if ever) that you would find it desirable not to use a 
- * mutation operator. However, if you find a crossover-only use-case, then simply
- * pass any mutation operator and 0.0 for the mutation rate to one of the constructors.</p>
+ * <p>The library also includes a class for mutation-only generational EAs
+ * (see {@link GenerationalMutationOnlyEvolutionaryAlgorithm}).</p>
  *
  * @param <T> The type of object under optimization.
  *
@@ -322,104 +319,6 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 		this(new BasePopulation.Integer<T>(n, initializer, f, selection, new ProgressTracker<T>()), f.getProblem(), mutation, mutationRate, crossover, crossoverRate, mutuallyExclusiveOps);
 	}
 	
-	
-	// Mutation-Only Constructors
-	
-	/**
-	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
-	 * with fitnesses of type double, the {@link FitnessFunction.Double} interface.
-	 *
-	 * @param n The population size.
-	 * @param mutation The mutation operator.
-	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
-	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
-	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
-	 *     interpretation of mutation rate, configure
-	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
-	 * @param initializer An initializer for generating random initial population members.
-	 * @param f The fitness function.
-	 * @param selection The selection operator.
-	 * @param tracker A ProgressTracker.
-	 *
-	 * @throws IllegalArgumentException if n is less than 1.
-	 * @throws IllegalArgumentException if mutationRate is less than 0.
-	 * @throws NullPointerException if any of mutation, initializer, f, selection, or tracker are null.
-	 */
-	public GenerationalEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Double<T> f, SelectionOperator selection, ProgressTracker<T> tracker) {
-		this(new BasePopulation.Double<T>(n, initializer, f, selection, tracker), f.getProblem(), mutation, mutationRate);
-	}
-	
-	/**
-	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
-	 * with fitnesses of type int, the {@link FitnessFunction.Integer} interface.
-	 *
-	 * @param n The population size.
-	 * @param mutation The mutation operator.
-	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
-	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
-	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
-	 *     interpretation of mutation rate, configure
-	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
-	 * @param initializer An initializer for generating random initial population members.
-	 * @param f The fitness function.
-	 * @param selection The selection operator.
-	 * @param tracker A ProgressTracker.
-	 *
-	 * @throws IllegalArgumentException if n is less than 1.
-	 * @throws IllegalArgumentException if mutationRate is less than 0.
-	 * @throws NullPointerException if any of mutation, initializer, f, selection, or tracker are null.
-	 */
-	public GenerationalEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Integer<T> f, SelectionOperator selection, ProgressTracker<T> tracker) {
-		this(new BasePopulation.Integer<T>(n, initializer, f, selection, tracker), f.getProblem(), mutation, mutationRate);
-	}
-	
-	/**
-	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
-	 * with fitnesses of type double, the {@link FitnessFunction.Double} interface.
-	 *
-	 * @param n The population size.
-	 * @param mutation The mutation operator.
-	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
-	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
-	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
-	 *     interpretation of mutation rate, configure
-	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
-	 * @param initializer An initializer for generating random initial population members.
-	 * @param f The fitness function.
-	 * @param selection The selection operator.
-	 *
-	 * @throws IllegalArgumentException if n is less than 1.
-	 * @throws IllegalArgumentException if mutationRate is less than 0.
-	 * @throws NullPointerException if any of mutation, initializer, f, or selection are null.
-	 */
-	public GenerationalEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Double<T> f, SelectionOperator selection) {
-		this(new BasePopulation.Double<T>(n, initializer, f, selection, new ProgressTracker<T>()), f.getProblem(), mutation, mutationRate);
-	}
-	
-	/**
-	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
-	 * with fitnesses of type int, the {@link FitnessFunction.Integer} interface.
-	 *
-	 * @param n The population size.
-	 * @param mutation The mutation operator.
-	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
-	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
-	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
-	 *     interpretation of mutation rate, configure
-	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
-	 * @param initializer An initializer for generating random initial population members.
-	 * @param f The fitness function.
-	 * @param selection The selection operator.
-	 *
-	 * @throws IllegalArgumentException if n is less than 1.
-	 * @throws IllegalArgumentException if mutationRate is less than 0.
-	 * @throws NullPointerException if any of mutation, initializer, f, or selection are null.
-	 */
-	public GenerationalEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Integer<T> f, SelectionOperator selection) {
-		this(new BasePopulation.Integer<T>(n, initializer, f, selection, new ProgressTracker<T>()), f.getProblem(), mutation, mutationRate);
-	}
-	
-	
 	// Internal Constructors
 	
 	/*
@@ -462,32 +361,6 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 	}
 	
 	/*
-	 * Internal helper constructor for Mutation-Only EAs.
-	 */
-	private GenerationalEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem, MutationOperator<T> mutation, double mutationRate) {
-		super(pop, problem);
-		if (mutation == null) {
-			throw new NullPointerException("mutation must be non-null");
-		}
-		if (mutationRate < 0.0) {
-			throw new IllegalArgumentException("mutationRate must not be negative");
-		}
-		this.mutation = mutation;
-		crossover = null;
-		C = 0.0;
-		
-		if (mutationRate < 1.0) {
-			M = mutationRate;
-			sr = mutationOnly(); 
-			go = GenerationOption.MUTATION_ONLY;
-		} else {
-			M = 1.0;
-			sr = alwaysMutate();
-			go = GenerationOption.ALWAYS_MUTATION;
-		}
-	}
-	
-	/*
 	 * Internal constructor for use by split method.
 	 * package private so subclasses in same package can use it for initialization for their own split methods.
 	 */
@@ -496,7 +369,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 		
 		// Must be split
 		mutation = other.mutation.split();
-		crossover = other.crossover != null ? other.crossover.split() : null; 
+		crossover = other.crossover.split(); 
 		
 		// Threadsafe so just copy reference or values
 		M = other.M;
@@ -507,10 +380,8 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 		switch (go) {
 			case FULL_GENERATION: sr = fullGeneration(); break;
 			case FULL_GENERATION_ALWAYS_MUTATE: sr = alwaysMutateFullGeneration(); break;
-			case MUTUALLY_EXCLUSIVE_OPERATORS: sr = mutuallyExclusiveOperators(); break;
-			case MUTATION_ONLY: sr = mutationOnly(); break;
-			default: //case ALWAYS_MUTATION: 
-				sr = alwaysMutate(); break;
+			default: //case MUTUALLY_EXCLUSIVE_OPERATORS: 
+				sr = mutuallyExclusiveOperators(); break;
 		}
 	}
 	
@@ -524,7 +395,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 	}
 	
 	private enum GenerationOption {
-		FULL_GENERATION, FULL_GENERATION_ALWAYS_MUTATE, MUTUALLY_EXCLUSIVE_OPERATORS, MUTATION_ONLY, ALWAYS_MUTATION
+		FULL_GENERATION, FULL_GENERATION_ALWAYS_MUTATE, MUTUALLY_EXCLUSIVE_OPERATORS
 	}
 	
 	@Override
@@ -607,33 +478,4 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>> extends Ab
 			return LAMBDA + count + count;
 		};
 	}
-	
-	private SingleGen<T> mutationOnly() {
-		return (pop) -> {
-			pop.select();
-			// Since select() above randomizes ordering, just use a binomial
-			// to get count of how many to mutate and mutate the first count individuals.
-			final int count = RandomVariates.nextBinomial(pop.mutableSize(), M);
-			for (int j = 0; j < count; j++) {
-				mutation.mutate(pop.get(j));
-				pop.updateFitness(j);
-			}
-			pop.replace();
-			return count;
-		};
-	}
-	
-	private SingleGen<T> alwaysMutate() {
-		return (pop) -> {
-			final int LAMBDA = pop.mutableSize();
-			pop.select();
-			for (int j = 0; j < LAMBDA; j++) {
-				mutation.mutate(pop.get(j));
-				pop.updateFitness(j);
-			}
-			pop.replace();
-			return LAMBDA;
-		};
-	}
-	
 }

--- a/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
@@ -1,0 +1,248 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2021  Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+import org.cicirello.util.Copyable;
+import org.cicirello.search.ProgressTracker;
+import org.cicirello.search.problems.Problem;
+import org.cicirello.search.operators.Initializer;
+import org.cicirello.search.operators.MutationOperator;
+import org.cicirello.math.rand.RandomVariates;
+
+/**
+ * <p>This class implements an evolutionary algorithm (EA) with a generational
+ * model, such as is commonly used in genetic algorithms, where a
+ * population of children are formed by applying mutation to
+ * members of the parent population, and where the children replace the 
+ * parents in the next generation. The EA implemented by this class does not
+ * use crossover.</p>
+ *
+ * <p>The mutation and selection operators are completely configurable
+ * by passing instances of classes that implement the
+ * {@link MutationOperator}, and {@link SelectionOperator} classes to one of the
+ * constructors.</p>
+ *
+ * <p>See the {@link GenerationalEvolutionaryAlgorithm} class for a generational EA
+ * with both crossover and mutation.</p>
+ *
+ * @param <T> The type of object under optimization.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>> extends AbstractEvolutionaryAlgorithm<T> {
+	
+	private final MutationOperator<T> mutation;
+	private final double M;
+	
+	private final SingleGen<T> sr;
+	private final GenerationOption go;
+	
+	/**
+	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
+	 * with fitnesses of type double, the {@link FitnessFunction.Double} interface.
+	 *
+	 * @param n The population size.
+	 * @param mutation The mutation operator.
+	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
+	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
+	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
+	 *     interpretation of mutation rate, configure
+	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
+	 * @param initializer An initializer for generating random initial population members.
+	 * @param f The fitness function.
+	 * @param selection The selection operator.
+	 * @param tracker A ProgressTracker.
+	 *
+	 * @throws IllegalArgumentException if n is less than 1.
+	 * @throws IllegalArgumentException if mutationRate is less than 0.
+	 * @throws NullPointerException if any of mutation, initializer, f, selection, or tracker are null.
+	 */
+	public GenerationalMutationOnlyEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Double<T> f, SelectionOperator selection, ProgressTracker<T> tracker) {
+		this(new BasePopulation.Double<T>(n, initializer, f, selection, tracker), f.getProblem(), mutation, mutationRate);
+	}
+	
+	/**
+	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
+	 * with fitnesses of type int, the {@link FitnessFunction.Integer} interface.
+	 *
+	 * @param n The population size.
+	 * @param mutation The mutation operator.
+	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
+	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
+	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
+	 *     interpretation of mutation rate, configure
+	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
+	 * @param initializer An initializer for generating random initial population members.
+	 * @param f The fitness function.
+	 * @param selection The selection operator.
+	 * @param tracker A ProgressTracker.
+	 *
+	 * @throws IllegalArgumentException if n is less than 1.
+	 * @throws IllegalArgumentException if mutationRate is less than 0.
+	 * @throws NullPointerException if any of mutation, initializer, f, selection, or tracker are null.
+	 */
+	public GenerationalMutationOnlyEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Integer<T> f, SelectionOperator selection, ProgressTracker<T> tracker) {
+		this(new BasePopulation.Integer<T>(n, initializer, f, selection, tracker), f.getProblem(), mutation, mutationRate);
+	}
+	
+	/**
+	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
+	 * with fitnesses of type double, the {@link FitnessFunction.Double} interface.
+	 *
+	 * @param n The population size.
+	 * @param mutation The mutation operator.
+	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
+	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
+	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
+	 *     interpretation of mutation rate, configure
+	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
+	 * @param initializer An initializer for generating random initial population members.
+	 * @param f The fitness function.
+	 * @param selection The selection operator.
+	 *
+	 * @throws IllegalArgumentException if n is less than 1.
+	 * @throws IllegalArgumentException if mutationRate is less than 0.
+	 * @throws NullPointerException if any of mutation, initializer, f, or selection are null.
+	 */
+	public GenerationalMutationOnlyEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Double<T> f, SelectionOperator selection) {
+		this(new BasePopulation.Double<T>(n, initializer, f, selection, new ProgressTracker<T>()), f.getProblem(), mutation, mutationRate);
+	}
+	
+	/**
+	 * Constructs and initializes the evolutionary algorithm with mutation only. This constructor supports fitness functions
+	 * with fitnesses of type int, the {@link FitnessFunction.Integer} interface.
+	 *
+	 * @param n The population size.
+	 * @param mutation The mutation operator.
+	 * @param mutationRate The probability that a member of the population is mutated once during a generation. Note that
+	 *     this is not a per-bit rate since this class is generalized to evolution of any {@link Copyable} object type.
+	 *     For {@link org.cicirello.search.representations.BitVector} optimization and traditional genetic algorithm 
+	 *     interpretation of mutation rate, configure
+	 *     your mutation operator with the per-bit mutation rate, and then pass 1.0 for this parameter.
+	 * @param initializer An initializer for generating random initial population members.
+	 * @param f The fitness function.
+	 * @param selection The selection operator.
+	 *
+	 * @throws IllegalArgumentException if n is less than 1.
+	 * @throws IllegalArgumentException if mutationRate is less than 0.
+	 * @throws NullPointerException if any of mutation, initializer, f, or selection are null.
+	 */
+	public GenerationalMutationOnlyEvolutionaryAlgorithm(int n, MutationOperator<T> mutation, double mutationRate, Initializer<T> initializer, FitnessFunction.Integer<T> f, SelectionOperator selection) {
+		this(new BasePopulation.Integer<T>(n, initializer, f, selection, new ProgressTracker<T>()), f.getProblem(), mutation, mutationRate);
+	}
+	
+	
+	// Internal Constructors
+	
+	/*
+	 * Internal helper constructor for Mutation-Only EAs.
+	 */
+	private GenerationalMutationOnlyEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem, MutationOperator<T> mutation, double mutationRate) {
+		super(pop, problem);
+		if (mutation == null) {
+			throw new NullPointerException("mutation must be non-null");
+		}
+		if (mutationRate < 0.0) {
+			throw new IllegalArgumentException("mutationRate must not be negative");
+		}
+		this.mutation = mutation;
+		
+		if (mutationRate < 1.0) {
+			M = mutationRate;
+			sr = mutationOnly(); 
+			go = GenerationOption.MUTATION_ONLY;
+		} else {
+			M = 1.0;
+			sr = alwaysMutate();
+			go = GenerationOption.ALWAYS_MUTATION;
+		}
+	}
+	
+	/*
+	 * Internal constructor for use by split method.
+	 * package private so subclasses in same package can use it for initialization for their own split methods.
+	 */
+	GenerationalMutationOnlyEvolutionaryAlgorithm(GenerationalMutationOnlyEvolutionaryAlgorithm<T> other) {
+		super(other);
+		
+		// Must be split
+		mutation = other.mutation.split();
+		
+		// Threadsafe so just copy reference or values
+		M = other.M;
+		
+		// Initialize the runner   
+		go = other.go;
+		switch (go) {
+			case MUTATION_ONLY: sr = mutationOnly(); break;
+			default: //case ALWAYS_MUTATION: 
+				sr = alwaysMutate(); break;
+		}
+	}
+	
+	@Override
+	public GenerationalMutationOnlyEvolutionaryAlgorithm<T> split() {
+		return new GenerationalMutationOnlyEvolutionaryAlgorithm<T>(this);
+	}
+		
+	private interface SingleGen<T extends Copyable<T>> {
+		int optimizeSingleGen(Population<T> pop);
+	}
+	
+	private enum GenerationOption {
+		MUTATION_ONLY, ALWAYS_MUTATION
+	}
+	
+	@Override
+	final int oneGeneration(Population<T> pop) {
+		return sr.optimizeSingleGen(pop);
+	}
+	
+	private SingleGen<T> mutationOnly() {
+		return (pop) -> {
+			pop.select();
+			// Since select() above randomizes ordering, just use a binomial
+			// to get count of how many to mutate and mutate the first count individuals.
+			final int count = RandomVariates.nextBinomial(pop.mutableSize(), M);
+			for (int j = 0; j < count; j++) {
+				mutation.mutate(pop.get(j));
+				pop.updateFitness(j);
+			}
+			pop.replace();
+			return count;
+		};
+	}
+	
+	private SingleGen<T> alwaysMutate() {
+		return (pop) -> {
+			final int LAMBDA = pop.mutableSize();
+			pop.select();
+			for (int j = 0; j < LAMBDA; j++) {
+				mutation.mutate(pop.get(j));
+				pop.updateFitness(j);
+			}
+			pop.replace();
+			return LAMBDA;
+		};
+	}
+	
+}

--- a/src/main/java/org/cicirello/search/evo/MutationOnlyGeneticAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/MutationOnlyGeneticAlgorithm.java
@@ -38,14 +38,15 @@ import org.cicirello.search.operators.bits.BitFlipMutation;
  * may be more relevant depending upon your use-case. For example, see the
  * {@link SimpleGeneticAlgorithm} class for the form of GA known as the Simple GA,
  * the {@link GeneticAlgorithm} class if you want to use both mutation and 
- * crossover, and the {@link GenerationalEvolutionaryAlgorithm} class if you want
+ * crossover, and the {@link GenerationalEvolutionaryAlgorithm} 
+ * and {@link GenerationalMutationOnlyEvolutionaryAlgorithm} classes if you want
  * to optimize something other than BitVectors or if you want even greater flexibility
  * in configuring your evolutionary search.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public final class MutationOnlyGeneticAlgorithm extends GenerationalEvolutionaryAlgorithm<BitVector> {
+public final class MutationOnlyGeneticAlgorithm extends GenerationalMutationOnlyEvolutionaryAlgorithm<BitVector> {
 	
 	// Constructors with an Initializer as parameter.
 	

--- a/src/test/java/org/cicirello/search/ProgressTrackerTests.java
+++ b/src/test/java/org/cicirello/search/ProgressTrackerTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -187,48 +187,6 @@ public class ProgressTrackerTests {
 			}
 		}
 	}
-	
-	@Test
-	@SuppressWarnings("deprecation")
-	public void testDeprecatedMethods() {
-		// Include this test method until the deprecated methods
-		// are removed. At that point, remove this. Continue to
-		// include for now as regression tests since some may still
-		// depend on these.
-		
-		// Test with int costs
-		ProgressTracker<TestCopyable> t = new ProgressTracker<TestCopyable>();
-		for (int i = 5; i >= 0; i--) {
-			assertFalse(t.didFindBest());
-			// Following is deprecated
-			t.update(i, new TestCopyable(i));
-		}
-		for (int i = 0; i <= 5; i++) {
-			assertFalse(t.didFindBest());
-			// Following is deprecated
-			t.update(i, new TestCopyable(i));
-		}
-		// Following is deprecated 
-		t.setFoundBest();
-		assertTrue(t.didFindBest());
-		
-		// Test with double costs
-		t = new ProgressTracker<TestCopyable>();
-		for (int i = 5; i >= 0; i--) {
-			assertFalse(t.didFindBest());
-			// Following is deprecated
-			t.update((double)i, new TestCopyable(i));
-		}
-		for (int i = 0; i <= 5; i++) {
-			assertFalse(t.didFindBest());
-			// Following is deprecated
-			t.update((double)i, new TestCopyable(i));
-		}
-		// Following is deprecated 
-		t.setFoundBest();
-		assertTrue(t.didFindBest());
-	}
-	
 	
 	private static class TestCopyable implements Copyable<TestCopyable> {
 		

--- a/src/test/java/org/cicirello/search/SolutionCostPairTests.java
+++ b/src/test/java/org/cicirello/search/SolutionCostPairTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2021 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 
@@ -52,28 +52,6 @@ public class SolutionCostPairTests {
 		
 		pairDouble = new SolutionCostPair<TestCopyable>(s, 10.0, true);
 		assertTrue(pairDouble.containsKnownOptimal());
-	}
-	
-	@Test
-	@SuppressWarnings("deprecation")
-	public void testDeprecatedMethods() {
-		// Include this test method until the deprecated constructors
-		// are removed. At that point, remove this. Continue to
-		// include for now as regression tests since some may still
-		// depend on these.
-		TestCopyable s = new TestCopyable(5);
-		SolutionCostPair<TestCopyable> pairInt = new SolutionCostPair<TestCopyable>(s, 10);
-		assertEquals(s, pairInt.getSolution());
-		assertTrue(pairInt.containsIntCost());
-		assertEquals(10, pairInt.getCost());
-		assertEquals(10.0, pairInt.getCostDouble(), EPSILON);
-		assertFalse(pairInt.containsKnownOptimal());
-		
-		SolutionCostPair<TestCopyable> pairDouble = new SolutionCostPair<TestCopyable>(s, 10.0);
-		assertEquals(s, pairDouble.getSolution());
-		assertFalse(pairDouble.containsIntCost());
-		assertEquals(10.0, pairDouble.getCostDouble(), EPSILON);
-		assertFalse(pairDouble.containsKnownOptimal());
 	}
 	
 	@Test

--- a/src/test/java/org/cicirello/search/evo/GenerationalEANoPTTests.java
+++ b/src/test/java/org/cicirello/search/evo/GenerationalEANoPTTests.java
@@ -33,7 +33,9 @@ import org.cicirello.search.operators.MutationOperator;
 import org.cicirello.search.operators.CrossoverOperator;
 
 /**
- * JUnit 4 test cases for GenerationalEvolutionaryAlgorithm, cases with constructors without ProgressTracker parameter.
+ * JUnit 4 test cases for GenerationalEvolutionaryAlgorithm and
+ * GenerationalMutationOnlyEvolutionaryAlgorithm, cases with constructors 
+ * without ProgressTracker parameter.
  */
 public class GenerationalEANoPTTests {
 	
@@ -41,7 +43,7 @@ public class GenerationalEANoPTTests {
 	public void testExceptions() {
 		NullPointerException thrownNull = assertThrows( 
 			NullPointerException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				null, 
 				0.5, 
@@ -52,7 +54,7 @@ public class GenerationalEANoPTTests {
 		);
 		thrownNull = assertThrows( 
 			NullPointerException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				null, 
 				0.5, 
@@ -171,7 +173,7 @@ public class GenerationalEANoPTTests {
 		);
 		IllegalArgumentException thrownIllegal = assertThrows( 
 			IllegalArgumentException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				new CountMutationCalls(), 
 				-1E-10, 
@@ -182,7 +184,7 @@ public class GenerationalEANoPTTests {
 		);
 		thrownIllegal = assertThrows( 
 			IllegalArgumentException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				new CountMutationCalls(), 
 				-1E-10, 
@@ -263,9 +265,9 @@ public class GenerationalEANoPTTests {
 	public void testStoppedByTracker() {
 		class TestThread extends Thread {
 			
-			GenerationalEvolutionaryAlgorithm<TestObject> ea;
+			GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea;
 			
-			public TestThread(GenerationalEvolutionaryAlgorithm<TestObject> ea) {
+			public TestThread(GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea) {
 				this.ea = ea;
 			}
 			
@@ -282,7 +284,7 @@ public class GenerationalEANoPTTests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -597,7 +599,7 @@ public class GenerationalEANoPTTests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -626,7 +628,7 @@ public class GenerationalEANoPTTests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		int oldMutationCount = mutation.count;
@@ -683,7 +685,7 @@ public class GenerationalEANoPTTests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			1.0, 
@@ -712,7 +714,7 @@ public class GenerationalEANoPTTests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		solution = ea.reoptimize(5);
@@ -1727,7 +1729,7 @@ public class GenerationalEANoPTTests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -1755,7 +1757,7 @@ public class GenerationalEANoPTTests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		int oldMutationCount = mutation.count;
@@ -1812,7 +1814,7 @@ public class GenerationalEANoPTTests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			1.0, 
@@ -1841,7 +1843,7 @@ public class GenerationalEANoPTTests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		solution = ea.reoptimize(5);

--- a/src/test/java/org/cicirello/search/evo/GenerationalEATests.java
+++ b/src/test/java/org/cicirello/search/evo/GenerationalEATests.java
@@ -33,7 +33,8 @@ import org.cicirello.search.operators.MutationOperator;
 import org.cicirello.search.operators.CrossoverOperator;
 
 /**
- * JUnit 4 test cases for GenerationalEvolutionaryAlgorithm.
+ * JUnit 4 test cases for GenerationalEvolutionaryAlgorithm 
+ * and GenerationalMutationOnlyEvolutionaryAlgorithm.
  */
 public class GenerationalEATests {
 	
@@ -41,7 +42,7 @@ public class GenerationalEATests {
 	public void testExceptions() {
 		NullPointerException thrownNull = assertThrows( 
 			NullPointerException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				null, 
 				0.5, 
@@ -53,7 +54,7 @@ public class GenerationalEATests {
 		);
 		thrownNull = assertThrows( 
 			NullPointerException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				null, 
 				0.5, 
@@ -181,7 +182,7 @@ public class GenerationalEATests {
 		);
 		IllegalArgumentException thrownIllegal = assertThrows( 
 			IllegalArgumentException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				new CountMutationCalls(), 
 				-1E-10, 
@@ -193,7 +194,7 @@ public class GenerationalEATests {
 		);
 		thrownIllegal = assertThrows( 
 			IllegalArgumentException.class,
-			() -> new GenerationalEvolutionaryAlgorithm<TestObject>(
+			() -> new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 				5, 
 				new CountMutationCalls(), 
 				-1E-10, 
@@ -280,9 +281,9 @@ public class GenerationalEATests {
 	public void testStoppedByTracker() {
 		class TestThread extends Thread {
 			
-			GenerationalEvolutionaryAlgorithm<TestObject> ea;
+			GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea;
 			
-			public TestThread(GenerationalEvolutionaryAlgorithm<TestObject> ea) {
+			public TestThread(GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea) {
 				this.ea = ea;
 			}
 			
@@ -300,7 +301,7 @@ public class GenerationalEATests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -629,7 +630,7 @@ public class GenerationalEATests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -661,7 +662,7 @@ public class GenerationalEATests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		int oldMutationCount = mutation.count;
@@ -719,7 +720,7 @@ public class GenerationalEATests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			1.0, 
@@ -751,7 +752,7 @@ public class GenerationalEATests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		solution = ea.reoptimize(5);
@@ -1807,7 +1808,7 @@ public class GenerationalEATests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			0.5, 
@@ -1838,7 +1839,7 @@ public class GenerationalEATests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		int oldMutationCount = mutation.count;
@@ -1896,7 +1897,7 @@ public class GenerationalEATests {
 		CountMutationCalls mutation = new CountMutationCalls();
 		final int N = 100;
 		
-		GenerationalEvolutionaryAlgorithm<TestObject> ea = new GenerationalEvolutionaryAlgorithm<TestObject>(
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea = new GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject>(
 			N, 
 			mutation, 
 			1.0, 
@@ -1928,7 +1929,7 @@ public class GenerationalEATests {
 		assertEquals(1, selection.initCount);
 		
 		// split it
-		GenerationalEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
+		GenerationalMutationOnlyEvolutionaryAlgorithm<TestObject> ea2 = ea.split();
 		
 		// reoptimize
 		solution = ea.reoptimize(5);

--- a/src/test/java/org/cicirello/search/hc/HillClimberTests.java
+++ b/src/test/java/org/cicirello/search/hc/HillClimberTests.java
@@ -333,7 +333,7 @@ public class HillClimberTests {
 		SolutionCostPair<TestObject> solution = null;
 		try {
 			do {
-				Thread.sleep(10);
+				Thread.sleep(20);
 			} while (!thread.started && problem.countEvals <= 1);
 			tracker.stop();		
 			solution = future.get();


### PR DESCRIPTION
### BREAKING CHANGES
* Next release will be 4.0.0 due to breaking changes.

### Added
* Added GenerationalMutationOnlyEvolutionaryAlgorithm, moving the mutation-only EA
  functionality into this new class from the existing GenerationalEvolutionaryAlgorithm
  class.

### Changed
* Refactored evolutionary algorithm classes to improve maintainability, and ease
  integration of planned future functionality.

### Removed
* Removed all mutation-only EA functionality from the GenerationalEvolutionaryAlgorithm,
  moving that functionality into the new GenerationalMutationOnlyEvolutionaryAlgorithm. This
  was done for maintainability. It is a breaking-change, although it should affect minimal
  users as the GenerationalEvolutionaryAlgorithm was just introduced. For this using it
  simply use the new GenerationalMutationOnlyEvolutionaryAlgorithm class where you will
  find all the same constructors and methods necessary for mutation-only EAs.
* All methods/constructors that were previously deprecated in earlier releases have 
  now been removed, including:
  * The following deprecated methods of the ProgressTracker class have been removed:
    * `update(int, T)` in favor of using `update(int, T, boolean)`.
    * `update(double, T)` in favor of using `update(double, T, boolean)`.
    * `setFoundBest()` in favor of using either `update(int, T, boolean)` 
      or `update(double, T, boolean)`.
  * The following deprecated constructors of the SolutionCostPair class have been removed:
    * `SolutionCostPair(T, int)` in favor of using `SolutionCostPair(T, int, boolean)`
    * `SolutionCostPair(T, double)` in favor of using `SolutionCostPair(T, double, boolean)`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
