### PR TITLE
Transformation from Permutation problem to BitVector problem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
         NEWLINE=$'\n'
         BODY="## JaCoCo Test Coverage Summary Statistics${NEWLINE}* __Coverage:__ ${COVERAGE}${NEWLINE}* __Branches:__ ${BRANCHES}"
         gh pr comment ${{github.event.pull_request.number}} -b "${BODY}"
+      continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,7 +1,5 @@
 jdkVersion = "11"
 
-summaryComments = true
-
 # don't run eslint... it is for js and will detect false positives 
 # in javadoc directories.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-01-06
+## [Unreleased] - 2022-01-13
 
 ### Added
 
@@ -17,9 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
-* Revised CI/CD workflows to deploy API website changes automatically upon each new release.
 
 ### Other
+
+
+## [4.1.0] - 2022-01-13
+
+### Added
+* Transformation between Permutation problem and BitVector problem, enabling using operators
+  for BitVectors when solving Permutation problems. 
+
+### CI/CD
+* Revised CI/CD workflows to deploy API website changes automatically upon each new release.
 
 
 ## [4.0.0] - 2022-01-05

--- a/src/main/java/org/cicirello/search/problems/IntegerCostOptimizationProblem.java
+++ b/src/main/java/org/cicirello/search/problems/IntegerCostOptimizationProblem.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021 Vincent A. Cicirello
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 

--- a/src/main/java/org/cicirello/search/problems/OptimizationProblem.java
+++ b/src/main/java/org/cicirello/search/problems/OptimizationProblem.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 

--- a/src/main/java/org/cicirello/search/problems/PermutationToBitVectorProblem.java
+++ b/src/main/java/org/cicirello/search/problems/PermutationToBitVectorProblem.java
@@ -35,6 +35,40 @@ import org.cicirello.search.operators.bits.BitVectorInitializer;
  * permutations of the desired length for the problem you are solving. In fact, to ensure that your search
  * is using the correct bit length, you should use this as your Initializer.</p>
  *
+ * <p>The mapping uses a classic transformation from vector of bits to a permutation of the N integers from 0 to N-1
+ * that works as follows. Consider a list of integers L initially containing the N integers in sorted
+ * order: L = [0, 1, 2, ..., N-1]. The list L is circular, such that any integer is an index into L. For example,
+ * if L is of length 5, indexes 0, 5, 10, etc all refer to the element in position 0. Likewise, indexes 1, 6, 11, etc
+ * all refer to the element in position 1, and so forth. The bit vector must be length: (N - 1) ceiling(lg N). Each
+ * contiguous group of ceiling(lg N) bits is treated as an index into L. There are N-1 such indexes available based
+ * on the bit vector length. Each such index is used to select an
+ * element from L, add it to the next available position of an initially empty permutation P, and remove it from L.
+ * After N-1 such operations, there will be one element left in L, which is then added to the end. The {@link #toPermutation toPermutation(BitVector)}
+ * method implements this transformation.</p>
+ *
+ * <p>Here is an example. Consider a very small permutation length N = 6. 
+ * For this length permutation, the bit vector must be (6 - 1) ceiling(lg 6) = 5 * 3 = 15 bits in length.
+ * Let's consider the transformation from the bit vector 111110001010100.</p>
+ * <ul>
+ * <li>L is initially L = [0, 1, 2, 3, 4, 5], and P is initially P = [].</li>
+ * <li>The first 3 bits, 111, is 7 in decimal, and 7 mod 6 = 1. L[1]=1, so we remove the
+ * 1 from L and add it to the end of P. This leads to L = [0, 2, 3, 4, 5], and P is P = [1].</li>
+ * <li>The next 3 bits, 110, is 6 in decimal, and 6 mod 5 = 1. L[1]=2, so we remove the
+ * 2 from L and add it to the end of P. This leads to L = [0, 3, 4, 5], and P is P = [1, 2].</li>
+ * <li>The next 3 bits, 001, is 1 in decimal, and 1 mod 4 = 1. L[1]=3, so we remove the
+ * 3 from L and add it to the end of P. This leads to L = [0, 4, 5], and P is P = [1, 2, 3].</li>
+ * <li>The next 3 bits, 010, is 2 in decimal, and 2 mod 3 = 2. L[2]=5, so we remove the
+ * 5 from L and add it to the end of P. This leads to L = [0, 4], and P is P = [1, 2, 3, 5].</li>
+ * <li>The last 3 bits, 100, is 4 in decimal, and 4 mod 2 = 0. L[0]=0, so we remove the
+ * 0 from L and add it to the end of P. This leads to L = [4], and P is P = [1, 2, 3, 5, 0].</li>
+ * <li>Reached the end of the bit vector, and there is only one element left in L, the 4, which
+ * we simply add to the end of P to arrive at P = [1, 2, 3, 5, 0, 4].</li>
+ * </ul>
+ *
+ * <p>This class has two nested subclasses, {@link DoubleCost} and {@link IntegerCost}, that handle
+ * the transformations from Permutation optimization problems with costs of type double and int, respectively
+ * (i.e., classes {@link OptimizationProblem} and {@link IntegerCostOptimizationProblem}).</p>
+ *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
@@ -70,7 +104,7 @@ public class PermutationToBitVectorProblem implements Initializer<BitVector> {
 	}
 	
 	@Override
-	public BitVector createCandidateSolution() {
+	public final BitVector createCandidateSolution() {
 		return init.createCandidateSolution();
 	}
 	
@@ -80,17 +114,50 @@ public class PermutationToBitVectorProblem implements Initializer<BitVector> {
 	}
 	
 	/**
-	 * Converts a BitVector to a Permutation.
+	 * Converts a BitVector to a Permutation. Assumes that the length of the BitVector bits
+	 * is supportedBitVectorLength(), and behavior is undefined otherwise.
 	 * @param bits The BitVector
 	 * @return A Permutation derived from the BitVector
 	 */
-	public Permutation toPermutation(BitVector bits) {
-		// TO DO
-		return null;
+	public final Permutation toPermutation(BitVector bits) {
+		Permutation p = new Permutation(permutationLength, 0);
+		if (permutationLength > 1) {
+			BitVector.BitIterator iter = bits.bitIterator(bitsPerElement);
+			for (int remaining = permutationLength; remaining > 1; remaining--) {
+				int j = permutationLength - remaining;
+				int i = j + (iter.nextBitBlock() % remaining);
+				if (i != j) {
+					p.removeAndInsert(i, j);
+				}
+			}
+		}
+		return p;
+	}
+	
+	/**
+	 * Computes the length of BitVectors supported by this instance.
+	 * @return the length of BitVectors supported by this instance
+	 */
+	public final int supportedBitVectorLength() {
+		return bitsPerElement * (permutationLength - 1);
 	}
 	
 	
-	
+	/**
+	 * <p>This class implements a mapping between Permutation problems and BitVector problems, where cost values are
+	 * of type double. This enables
+	 * using {@link BitVector BitVector} search operators to solve problems defined over the space of
+	 * {@link Permutation Permutation} objects. It can also be used as an {@link Initializer} of BitVectors
+	 * by search algorithms to ensure that the search is using BitVectors of the appropriate length to represent
+	 * permutations of the desired length for the problem you are solving. In fact, to ensure that your search
+	 * is using the correct bit length, you should use this as your Initializer.</p>
+	 *
+	 * <p>The superclass, {@link PermutationToBitVectorProblem}, handles the transformation between BitVectors and
+	 * Permutations. See that class's documentation for the details of how a BitVector is interpreted as a Permutation.</p>
+	 *
+	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+	 */
 	public static final class DoubleCost extends PermutationToBitVectorProblem implements OptimizationProblem<BitVector> {
 		
 		private final OptimizationProblem<Permutation> problem;
@@ -137,12 +204,6 @@ public class PermutationToBitVectorProblem implements Initializer<BitVector> {
 		}
 		
 		@Override
-		public SolutionCostPair<BitVector> getSolutionCostPair(BitVector candidate) {
-			double c = cost(candidate);
-			return new SolutionCostPair<BitVector>(candidate, c, isMinCost(c));
-		}
-		
-		@Override
 		public boolean isMinCost(double cost) {
 			return problem.isMinCost(cost);
 		}
@@ -158,6 +219,21 @@ public class PermutationToBitVectorProblem implements Initializer<BitVector> {
 		}
 	}
 	
+	/**
+	 * <p>This class implements a mapping between Permutation problems and BitVector problems, where cost values are
+	 * of type int. This enables
+	 * using {@link BitVector BitVector} search operators to solve problems defined over the space of
+	 * {@link Permutation Permutation} objects. It can also be used as an {@link Initializer} of BitVectors
+	 * by search algorithms to ensure that the search is using BitVectors of the appropriate length to represent
+	 * permutations of the desired length for the problem you are solving. In fact, to ensure that your search
+	 * is using the correct bit length, you should use this as your Initializer.</p>
+	 *
+	 * <p>The superclass, {@link PermutationToBitVectorProblem}, handles the transformation between BitVectors and
+	 * Permutations. See that class's documentation for the details of how a BitVector is interpreted as a Permutation.</p>
+	 *
+	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+	 */
 	public static final class IntegerCost extends PermutationToBitVectorProblem implements IntegerCostOptimizationProblem<BitVector> {
 		
 		private final IntegerCostOptimizationProblem<Permutation> problem;
@@ -201,12 +277,6 @@ public class PermutationToBitVectorProblem implements Initializer<BitVector> {
 		@Override
 		public double costAsDouble(BitVector candidate) {
 			return problem.costAsDouble(toPermutation(candidate));
-		}
-		
-		@Override
-		public SolutionCostPair<BitVector> getSolutionCostPair(BitVector candidate) {
-			int c = cost(candidate);
-			return new SolutionCostPair<BitVector>(candidate, c, isMinCost(c));
 		}
 		
 		@Override

--- a/src/main/java/org/cicirello/search/problems/PermutationToBitVectorProblem.java
+++ b/src/main/java/org/cicirello/search/problems/PermutationToBitVectorProblem.java
@@ -1,0 +1,227 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.problems;
+
+import org.cicirello.util.Copyable;
+import org.cicirello.search.SolutionCostPair;
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.search.operators.Initializer;
+import org.cicirello.search.operators.bits.BitVectorInitializer;
+
+/**
+ * <p>This class implements a mapping between Permutation problems and BitVector problems,
+ * enabling using {@link BitVector BitVector} search operators to solve problems defined over the space of
+ * {@link Permutation Permutation} objects. It can also be used as an {@link Initializer} of BitVectors
+ * by search algorithms to ensure that the search is using BitVectors of the appropriate length to represent
+ * permutations of the desired length for the problem you are solving. In fact, to ensure that your search
+ * is using the correct bit length, you should use this as your Initializer.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public class PermutationToBitVectorProblem implements Initializer<BitVector> {
+	
+	private final BitVectorInitializer init;
+	private final int bitsPerElement;
+	private final int permutationLength;
+	
+	/**
+	 * Initializes the PermutationToBitVectorProblem mapping for a specific permutation length.
+	 *
+	 * @param permutationLength The length of the permutations under optimization, in number of elements.
+	 *     This is NOT the length of the BitVectors. For example, if the problem is the Traveling Salesperson,
+	 *     and if the instance has 100 cities, then you would pass 100 for this parameter.
+	 *
+	 * @throws IllegalArgumentException if permutationLength is less than 1.
+	 */
+	public PermutationToBitVectorProblem(int permutationLength) {
+		if (permutationLength < 1) throw new IllegalArgumentException("permutationLength must be positive");
+		bitsPerElement = 32 - Integer.numberOfLeadingZeros(permutationLength-1);
+		init = new BitVectorInitializer(bitsPerElement * (permutationLength - 1));
+		this.permutationLength = permutationLength;
+	}
+	
+	/*
+	 * package private for use by split
+	 */
+	PermutationToBitVectorProblem(PermutationToBitVectorProblem other) {
+		init = other.init.split();
+		bitsPerElement = other.bitsPerElement;
+		permutationLength = other.permutationLength;
+	}
+	
+	@Override
+	public BitVector createCandidateSolution() {
+		return init.createCandidateSolution();
+	}
+	
+	@Override
+	public PermutationToBitVectorProblem split() {
+		return new PermutationToBitVectorProblem(this);
+	}
+	
+	/**
+	 * Converts a BitVector to a Permutation.
+	 * @param bits The BitVector
+	 * @return A Permutation derived from the BitVector
+	 */
+	public Permutation toPermutation(BitVector bits) {
+		// TO DO
+		return null;
+	}
+	
+	
+	
+	public static final class DoubleCost extends PermutationToBitVectorProblem implements OptimizationProblem<BitVector> {
+		
+		private final OptimizationProblem<Permutation> problem;
+		
+		/**
+		 * Initializes the mapping between Permutation problem and BitVector problem for a specific permutation length.
+		 *
+		 * @param problem The original Permutation problem.
+		 *
+		 * @param permutationLength The length of the permutations under optimization, in number of elements.
+		 *     This is NOT the length of the BitVectors. For example, if the problem is the Traveling Salesperson,
+		 *     and if the instance has 100 cities, then you would pass 100 for this parameter.
+		 *
+		 * @throws IllegalArgumentException if permutationLength is less than 1.
+		 */
+		public DoubleCost(OptimizationProblem<Permutation> problem, int permutationLength) {
+			super(permutationLength);
+			this.problem = problem;
+		}
+		
+		/*
+		 * package private for use by split
+		 */
+		DoubleCost(DoubleCost other) {
+			super(other);
+			
+			// thread safe so just copy reference
+			problem = other.problem;
+		}
+		
+		@Override
+		public DoubleCost split() {
+			return new DoubleCost(this);
+		}
+		
+		@Override
+		public double cost(BitVector candidate) {
+			return problem.cost(toPermutation(candidate));
+		}
+		
+		@Override
+		public double costAsDouble(BitVector candidate) {
+			return problem.costAsDouble(toPermutation(candidate));
+		}
+		
+		@Override
+		public SolutionCostPair<BitVector> getSolutionCostPair(BitVector candidate) {
+			double c = cost(candidate);
+			return new SolutionCostPair<BitVector>(candidate, c, isMinCost(c));
+		}
+		
+		@Override
+		public boolean isMinCost(double cost) {
+			return problem.isMinCost(cost);
+		}
+		
+		@Override
+		public double minCost() {
+			return problem.minCost();
+		}
+		
+		@Override
+		public double value(BitVector candidate) {
+			return problem.value(toPermutation(candidate));
+		}
+	}
+	
+	public static final class IntegerCost extends PermutationToBitVectorProblem implements IntegerCostOptimizationProblem<BitVector> {
+		
+		private final IntegerCostOptimizationProblem<Permutation> problem;
+		
+		/**
+		 * Initializes the mapping between Permutation problem and BitVector problem for a specific permutation length.
+		 *
+		 * @param problem The original Permutation problem.
+		 *
+		 * @param permutationLength The length of the permutations under optimization, in number of elements.
+		 *     This is NOT the length of the BitVectors. For example, if the problem is the Traveling Salesperson,
+		 *     and if the instance has 100 cities, then you would pass 100 for this parameter.
+		 *
+		 * @throws IllegalArgumentException if permutationLength is less than 1.
+		 */
+		public IntegerCost(IntegerCostOptimizationProblem<Permutation> problem, int permutationLength) {
+			super(permutationLength);
+			this.problem = problem;
+		}
+		
+		/*
+		 * package private for use by split
+		 */
+		IntegerCost(IntegerCost other) {
+			super(other);
+			
+			// thread safe so just copy reference
+			problem = other.problem;
+		}
+		
+		@Override
+		public IntegerCost split() {
+			return new IntegerCost(this);
+		}
+		
+		@Override
+		public int cost(BitVector candidate) {
+			return problem.cost(toPermutation(candidate));
+		}
+		
+		@Override
+		public double costAsDouble(BitVector candidate) {
+			return problem.costAsDouble(toPermutation(candidate));
+		}
+		
+		@Override
+		public SolutionCostPair<BitVector> getSolutionCostPair(BitVector candidate) {
+			int c = cost(candidate);
+			return new SolutionCostPair<BitVector>(candidate, c, isMinCost(c));
+		}
+		
+		@Override
+		public boolean isMinCost(int cost) {
+			return problem.isMinCost(cost);
+		}
+		
+		@Override
+		public int minCost() {
+			return problem.minCost();
+		}
+		
+		@Override
+		public int value(BitVector candidate) {
+			return problem.value(toPermutation(candidate));
+		}
+	}
+}

--- a/src/main/java/org/cicirello/search/problems/Problem.java
+++ b/src/main/java/org/cicirello/search/problems/Problem.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  * 

--- a/src/test/java/org/cicirello/search/problems/PermutationBitVectorTests.java
+++ b/src/test/java/org/cicirello/search/problems/PermutationBitVectorTests.java
@@ -1,0 +1,255 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.problems;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.permutations.distance.ExactMatchDistance;
+import org.cicirello.search.representations.BitVector;
+import org.cicirello.search.SolutionCostPair;
+
+/**
+ * JUnit Tests for PermutationToBitVectorProblem and its nested subclasses.
+ */
+public class PermutationBitVectorTests {
+	
+	@Test
+	public void testConversionBaseClass() {
+		Permutation[] expected = {
+			new Permutation(1, 0), new Permutation(2, 0), new Permutation(3, 0), new Permutation(4, 0),
+			new Permutation(5, 0), new Permutation(6, 0), new Permutation(7, 0), new Permutation(8, 0),
+			new Permutation(9, 0), new Permutation(10, 0), new Permutation(11, 0), new Permutation(12, 0),
+			new Permutation(13, 0), new Permutation(14, 0), new Permutation(15, 0), new Permutation(16, 0)
+		};
+		int[] expectedBitLengths = {0, 1, 2*2, 2*3, 3*4, 3*5, 3*6, 3*7, 4*8, 4*9, 4*10, 4*11, 4*12, 4*13, 4*14, 4*15};
+		int[][] modCases = {
+			{0}, {0}, {11}, {44}, {1253}, {0x272e}, {0x13977}, {0x9cbb8},
+			{0x23456789}, {0x3456789a, 0x2}, {0x456789ab, 0x23}, {0x56789abc, 0x234}, 
+			{0x6789abcd, 0x2345}, {0x789abcde, 0x23456}, {0x89abcdef, 0x234567}, {0x9abcdef0, 0x2345678}
+		};
+		for (int i = 0; i < expected.length; i++) {
+			PermutationToBitVectorProblem converter = new PermutationToBitVectorProblem(expected[i].length());
+			assertEquals(expectedBitLengths[i], converter.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], converter.createCandidateSolution().length());
+			assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+			}
+			
+			PermutationToBitVectorProblem split = converter.split();
+			assertTrue(converter != split);
+			assertEquals(expectedBitLengths[i], split.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], split.createCandidateSolution().length());
+			assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+			}
+			
+			expected[i].reverse();
+			int[][] reversedCases = {
+				{0}, {1}, {6}, {0x1b}, {0x29c}, {0x14e5}, {0xa72e}, {0x53977},
+				{0x12345678}, {0x23456789, 0x1}, {0x3456789a, 0x12}, {0x456789ab, 0x123}, 
+				{0x56789abc, 0x1234}, {0x6789abcd, 0x12345}, {0x789abcde, 0x123456}, {0x89abcdef, 0x1234567}
+			};
+			if (i < reversedCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new PermutationToBitVectorProblem(0)
+		);
+		
+	}
+	
+	@Test
+	public void testIntegerCosts() {
+		Permutation[] expected = {
+			new Permutation(1, 0), new Permutation(2, 0), new Permutation(3, 0), new Permutation(4, 0),
+			new Permutation(5, 0), new Permutation(6, 0), new Permutation(7, 0), new Permutation(8, 0),
+			new Permutation(9, 0), new Permutation(10, 0), new Permutation(11, 0), new Permutation(12, 0),
+			new Permutation(13, 0), new Permutation(14, 0), new Permutation(15, 0), new Permutation(16, 0)
+		};
+		int[] expectedBitLengths = {0, 1, 2*2, 2*3, 3*4, 3*5, 3*6, 3*7, 4*8, 4*9, 4*10, 4*11, 4*12, 4*13, 4*14, 4*15};
+		int[][] modCases = {
+			{0}, {0}, {11}, {44}, {1253}, {0x272e}, {0x13977}, {0x9cbb8},
+			{0x23456789}, {0x3456789a, 0x2}, {0x456789ab, 0x23}, {0x56789abc, 0x234}, 
+			{0x6789abcd, 0x2345}, {0x789abcde, 0x23456}, {0x89abcdef, 0x234567}, {0x9abcdef0, 0x2345678}
+		};
+		for (int i = 0; i < expected.length; i++) {
+			PermutationInAHaystack problem = new PermutationInAHaystack(new ExactMatchDistance(), expected[i].copy()); 
+			PermutationToBitVectorProblem.IntegerCost converter = new PermutationToBitVectorProblem.IntegerCost(problem, expected[i].length());
+			assertEquals(expectedBitLengths[i], converter.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], converter.createCandidateSolution().length());
+			assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+				assertEquals(0, converter.cost(new BitVector(expectedBitLengths[i], modCases[i])));
+				assertEquals(0.0, converter.costAsDouble(new BitVector(expectedBitLengths[i], modCases[i])), 1E-10);
+				assertEquals(0, converter.value(new BitVector(expectedBitLengths[i], modCases[i])));
+			}
+			assertEquals(0, converter.cost(new BitVector(expectedBitLengths[i])));
+			assertEquals(0, converter.value(new BitVector(expectedBitLengths[i])));
+			assertEquals(0.0, converter.costAsDouble(new BitVector(expectedBitLengths[i])), 1E-10);
+			assertTrue(converter.isMinCost(0));
+			assertFalse(converter.isMinCost(1));
+			assertEquals(0, converter.minCost());
+			SolutionCostPair<BitVector> pair = converter.getSolutionCostPair(new BitVector(expectedBitLengths[i]));
+			assertEquals(0, pair.getCost());
+			assertEquals(new BitVector(expectedBitLengths[i]), pair.getSolution());
+			
+			PermutationToBitVectorProblem.IntegerCost split = converter.split();
+			assertTrue(converter != split);
+			assertEquals(expectedBitLengths[i], split.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], split.createCandidateSolution().length());
+			assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+			}
+			
+			expected[i].reverse();
+			int[][] reversedCases = {
+				{0}, {1}, {6}, {0x1b}, {0x29c}, {0x14e5}, {0xa72e}, {0x53977},
+				{0x12345678}, {0x23456789, 0x1}, {0x3456789a, 0x12}, {0x456789ab, 0x123}, 
+				{0x56789abc, 0x1234}, {0x6789abcd, 0x12345}, {0x789abcde, 0x123456}, {0x89abcdef, 0x1234567}
+			};
+			if (i < reversedCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.cost(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.value(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.costAsDouble(new BitVector(expectedBitLengths[i], reversedCases[i])), 1E-10);
+				pair = converter.getSolutionCostPair(new BitVector(expectedBitLengths[i], reversedCases[i]));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, pair.getCost());
+				assertEquals(new BitVector(expectedBitLengths[i], reversedCases[i]), pair.getSolution());
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new PermutationToBitVectorProblem.IntegerCost(new PermutationInAHaystack(new ExactMatchDistance(), 10), 0)
+		);
+	}
+	
+	@Test
+	public void testDoubleCosts() {
+		Permutation[] expected = {
+			new Permutation(1, 0), new Permutation(2, 0), new Permutation(3, 0), new Permutation(4, 0),
+			new Permutation(5, 0), new Permutation(6, 0), new Permutation(7, 0), new Permutation(8, 0),
+			new Permutation(9, 0), new Permutation(10, 0), new Permutation(11, 0), new Permutation(12, 0),
+			new Permutation(13, 0), new Permutation(14, 0), new Permutation(15, 0), new Permutation(16, 0)
+		};
+		int[] expectedBitLengths = {0, 1, 2*2, 2*3, 3*4, 3*5, 3*6, 3*7, 4*8, 4*9, 4*10, 4*11, 4*12, 4*13, 4*14, 4*15};
+		int[][] modCases = {
+			{0}, {0}, {11}, {44}, {1253}, {0x272e}, {0x13977}, {0x9cbb8},
+			{0x23456789}, {0x3456789a, 0x2}, {0x456789ab, 0x23}, {0x56789abc, 0x234}, 
+			{0x6789abcd, 0x2345}, {0x789abcde, 0x23456}, {0x89abcdef, 0x234567}, {0x9abcdef0, 0x2345678}
+		};
+		for (int i = 0; i < expected.length; i++) {
+			TestProblem problem = new TestProblem(expected[i].copy()); 
+			PermutationToBitVectorProblem.DoubleCost converter = new PermutationToBitVectorProblem.DoubleCost(problem, expected[i].length());
+			assertEquals(expectedBitLengths[i], converter.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], converter.createCandidateSolution().length());
+			assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+				assertEquals(0.0, converter.cost(new BitVector(expectedBitLengths[i], modCases[i])), 1E-10);
+				assertEquals(0.0, converter.costAsDouble(new BitVector(expectedBitLengths[i], modCases[i])), 1E-10);
+				assertEquals(0.0, converter.value(new BitVector(expectedBitLengths[i], modCases[i])), 1E-10);
+			}
+			assertEquals(0.0, converter.cost(new BitVector(expectedBitLengths[i])), 1E-10);
+			assertEquals(0.0, converter.value(new BitVector(expectedBitLengths[i])), 1E-10);
+			assertEquals(0.0, converter.costAsDouble(new BitVector(expectedBitLengths[i])), 1E-10);
+			assertTrue(converter.isMinCost(0));
+			assertFalse(converter.isMinCost(1));
+			assertEquals(0.0, converter.minCost(), 1E-10);
+			SolutionCostPair<BitVector> pair = converter.getSolutionCostPair(new BitVector(expectedBitLengths[i]));
+			assertEquals(0.0, pair.getCostDouble(), 1E-10);
+			assertEquals(new BitVector(expectedBitLengths[i]), pair.getSolution());
+			
+			PermutationToBitVectorProblem.DoubleCost split = converter.split();
+			assertTrue(converter != split);
+			assertEquals(expectedBitLengths[i], split.supportedBitVectorLength());
+			assertEquals(expectedBitLengths[i], split.createCandidateSolution().length());
+			assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i])));
+			if (i < modCases.length && i > 0) {
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], modCases[i])));
+			}
+			
+			expected[i].reverse();
+			int[][] reversedCases = {
+				{0}, {1}, {6}, {0x1b}, {0x29c}, {0x14e5}, {0xa72e}, {0x53977},
+				{0x12345678}, {0x23456789, 0x1}, {0x3456789a, 0x12}, {0x456789ab, 0x123}, 
+				{0x56789abc, 0x1234}, {0x6789abcd, 0x12345}, {0x789abcde, 0x123456}, {0x89abcdef, 0x1234567}
+			};
+			if (i < reversedCases.length && i > 0) {
+				assertEquals(expected[i], converter.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i], split.toPermutation(new BitVector(expectedBitLengths[i], reversedCases[i])));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.cost(new BitVector(expectedBitLengths[i], reversedCases[i])), 1E-10);
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.value(new BitVector(expectedBitLengths[i], reversedCases[i])), 1E-10);
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, converter.costAsDouble(new BitVector(expectedBitLengths[i], reversedCases[i])), 1E-10);
+				pair = converter.getSolutionCostPair(new BitVector(expectedBitLengths[i], reversedCases[i]));
+				assertEquals(expected[i].length()%2==0?expected[i].length():expected[i].length()-1, pair.getCostDouble(), 1E-10);
+				assertEquals(new BitVector(expectedBitLengths[i], reversedCases[i]), pair.getSolution());
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new PermutationToBitVectorProblem.DoubleCost(new TestProblem(new Permutation(10)), 0)
+		);
+	}
+	
+	private static class TestProblem implements OptimizationProblem<Permutation> {
+		
+		private PermutationInAHaystack problem;
+		
+		public TestProblem(Permutation perm) {
+			problem = new PermutationInAHaystack(new ExactMatchDistance(), perm);
+		}
+		
+		@Override
+		public double cost(Permutation p) {
+			return problem.cost(p);
+		}
+		
+		@Override
+		public double value(Permutation p) {
+			return problem.value(p);
+		}
+		
+		@Override
+		public double costAsDouble(Permutation p) {
+			return problem.cost(p);
+		}
+		
+		@Override
+		public double minCost() {
+			return 0.0;
+		}
+		
+		@Override
+		public boolean isMinCost(double c) {
+			return c==0.0;
+		}
+	}
+	
+}


### PR DESCRIPTION
## Summary
Added the class PermutationToBitVectorProblem, which includes wrappers of OptimizationProblem<Permutation> and IntegerCostOptimizationProblem<Permutation> implementing OptimizationProblem<BitVector> and IntegerCostOptimizationProblem<BitVector>. The purpose is to enable easily comparing performance of Permutation vs BitVector representations on a problem without the need to reimplement the problem for each representation. The mapping uses a simple classic mapping from bits to permutations.

## Closing Issues
Closes #355 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
