### PR TITLE
Fix tsp lower bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-01-24
+## [Unreleased] - 2022-01-27
 
 ### Added
 
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI/CD
 
 ### Other
+
+
+## [4.2.1] - 2022-01-27
+
+### Fixed
+* Implemented the optional method, minCost, of the OptimizationProblem and
+  IntegerCostOptimizationProblem classes in all of the various TSP implementations
+  to return a simple, extremely loose, lower bound of 0, to enable using the
+  InverseCostFitnessFunction class that require a finite lower bound. The default
+  implementation of that method otherwise returns negative infinity.
 
 
 ## [4.2.0] - 2022-01-24

--- a/src/main/java/org/cicirello/search/problems/tsp/RandomTSPMatrix.java
+++ b/src/main/java/org/cicirello/search/problems/tsp/RandomTSPMatrix.java
@@ -219,6 +219,11 @@ public abstract class RandomTSPMatrix extends BaseTSP {
 			return cost(candidate);
 		}
 		
+		@Override
+		public int minCost() {
+			return 0;
+		}
+		
 		/*
 		 * package private to support implementing heuristics in same package.
 		 */
@@ -459,6 +464,11 @@ public abstract class RandomTSPMatrix extends BaseTSP {
 		@Override
 		public double value(Permutation candidate) {
 			return cost(candidate);
+		}
+		
+		@Override
+		public double minCost() {
+			return 0;
 		}
 		
 		/*

--- a/src/main/java/org/cicirello/search/problems/tsp/TSP.java
+++ b/src/main/java/org/cicirello/search/problems/tsp/TSP.java
@@ -256,6 +256,11 @@ public abstract class TSP extends BaseTSP {
 			return cost(candidate);
 		}
 		
+		@Override
+		public double minCost() {
+			return 0;
+		}
+		
 		/*
 		 * package private to support implementing heuristics in same package.
 		 */
@@ -380,6 +385,11 @@ public abstract class TSP extends BaseTSP {
 		@Override
 		public int value(Permutation candidate) {
 			return cost(candidate);
+		}
+		
+		@Override
+		public int minCost() {
+			return 0;
 		}
 		
 		/*
@@ -512,6 +522,11 @@ public abstract class TSP extends BaseTSP {
 		@Override
 		public double value(Permutation candidate) {
 			return cost(candidate);
+		}
+		
+		@Override
+		public double minCost() {
+			return 0;
 		}
 		
 		private double[][] computeWeights() {
@@ -652,6 +667,11 @@ public abstract class TSP extends BaseTSP {
 		@Override
 		public int value(Permutation candidate) {
 			return cost(candidate);
+		}
+		
+		@Override
+		public int minCost() {
+			return 0;
 		}
 		
 		private int[][] computeWeights() {

--- a/src/test/java/org/cicirello/search/problems/tsp/RandomTSPMatrixTests.java
+++ b/src/test/java/org/cicirello/search/problems/tsp/RandomTSPMatrixTests.java
@@ -151,6 +151,7 @@ public class RandomTSPMatrixTests {
 		int[][] matrix2 = { {7, 3}, {5, 9} };
 		int[][] expected2 = { {7, 3}, {5, 9} };
 		RandomTSPMatrix.Integer tsp = new RandomTSPMatrix.Integer(matrix2);
+		assertEquals(0, tsp.minCost());
 		assertEquals(2, tsp.length());
 		for (int i = 0; i < expected2.length; i++) {
 			for (int j = 0; j < expected2[i].length; j++) {
@@ -321,6 +322,7 @@ public class RandomTSPMatrixTests {
 		double[][] matrix2 = { {7, 3}, {5, 9} };
 		double[][] expected2 = { {7, 3}, {5, 9} };
 		RandomTSPMatrix.Double tsp = new RandomTSPMatrix.Double(matrix2);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(2, tsp.length());
 		for (int i = 0; i < expected2.length; i++) {
 			for (int j = 0; j < expected2[i].length; j++) {

--- a/src/test/java/org/cicirello/search/problems/tsp/TSPTests.java
+++ b/src/test/java/org/cicirello/search/problems/tsp/TSPTests.java
@@ -212,6 +212,7 @@ public class TSPTests {
 			{ Math.sqrt(52.0), 6.0, 0.0 }
 		};
 		TSP.Double tsp = new TSP.Double(x, y);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -254,6 +255,7 @@ public class TSPTests {
 			y,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -287,6 +289,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.Double tsp = new TSP.Double(N, W);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -326,6 +329,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.Double tsp = new TSP.Double(N, W, 42);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -367,6 +371,7 @@ public class TSPTests {
 		TSP.Double tsp = new TSP.Double(N, W,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -406,6 +411,7 @@ public class TSPTests {
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2),
 			42
 		);
+		assertEquals(0.0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -450,6 +456,7 @@ public class TSPTests {
 			{ 7, 6, 0 }
 		};
 		TSP.Integer tsp = new TSP.Integer(x, y);
+		assertEquals(0, tsp.minCost());
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -492,6 +499,7 @@ public class TSPTests {
 			y,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -525,6 +533,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.Integer tsp = new TSP.Integer(N, W);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -564,6 +573,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.Integer tsp = new TSP.Integer(N, W, 42);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -605,6 +615,7 @@ public class TSPTests {
 		TSP.Integer tsp = new TSP.Integer(N, W,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -644,6 +655,7 @@ public class TSPTests {
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2),
 			42
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -688,6 +700,7 @@ public class TSPTests {
 			{ Math.sqrt(52.0), 6.0, 0.0 }
 		};
 		TSP.DoubleMatrix tsp = new TSP.DoubleMatrix(x, y);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -730,6 +743,7 @@ public class TSPTests {
 			y,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -763,6 +777,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.DoubleMatrix tsp = new TSP.DoubleMatrix(N, W);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -802,6 +817,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.DoubleMatrix tsp = new TSP.DoubleMatrix(N, W, 42);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -843,6 +859,7 @@ public class TSPTests {
 		TSP.DoubleMatrix tsp = new TSP.DoubleMatrix(N, W,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -882,6 +899,7 @@ public class TSPTests {
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2),
 			42
 		);
+		assertEquals(0, tsp.minCost(), 0.0);
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -926,6 +944,7 @@ public class TSPTests {
 			{ 7, 6, 0 }
 		};
 		TSP.IntegerMatrix tsp = new TSP.IntegerMatrix(x, y);
+		assertEquals(0, tsp.minCost());
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -968,6 +987,7 @@ public class TSPTests {
 			y,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(x.length, tsp.x.length);
 		assertEquals(y.length, tsp.y.length);
 		assertTrue(x != tsp.x);
@@ -1001,6 +1021,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.IntegerMatrix tsp = new TSP.IntegerMatrix(N, W);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -1040,6 +1061,7 @@ public class TSPTests {
 		int W = 5;
 		int N = 10;
 		TSP.IntegerMatrix tsp = new TSP.IntegerMatrix(N, W, 42);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -1081,6 +1103,7 @@ public class TSPTests {
 		TSP.IntegerMatrix tsp = new TSP.IntegerMatrix(N, W,
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2)
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {
@@ -1120,6 +1143,7 @@ public class TSPTests {
 			(x1, y1, x2, y2) -> Math.abs(x1-x2) + Math.abs(y1-y2),
 			42
 		);
+		assertEquals(0, tsp.minCost());
 		assertEquals(N, tsp.x.length);
 		assertEquals(N, tsp.y.length);
 		for (int i = 0; i < N; i++) {


### PR DESCRIPTION
## Summary
Implemented the optional method, minCost, of the OptimizationProblem and IntegerCostOptimizationProblem classes in all of the various TSP implementations to return a simple, extremely loose, lower bound of 0, to enable using the InverseCostFitnessFunction class that require a finite lower bound. The default implementation of that method otherwise returns negative infinity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
