### PR TITLE
Bumped rho-mu to 1.2.0 and edited test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Bumped dependency rho-mu to 1.2.0
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
 		<dependency>
 			<groupId>org.cicirello</groupId>
 			<artifactId>rho-mu</artifactId>
-			<version>1.1.0</version>
+			<version>1.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cicirello</groupId>

--- a/src/test/java/org/cicirello/search/evo/SelectionOperatorTests.java
+++ b/src/test/java/org/cicirello/search/evo/SelectionOperatorTests.java
@@ -141,8 +141,10 @@ public class SelectionOperatorTests {
 			validateIndexes_Integer(selection2);
 		}
 		LinearRankSelection selection = new LinearRankSelection(2.0);
-		validateHigherFitnessSelectedMoreOften_Double(selection);
-		validateHigherFitnessSelectedMoreOften_Integer(selection);
+		// Following two checks may sporadically fail due to random chance.
+		// Increase 2nd parameter to decrease probability of such failure (keep it even though).
+		validateHigherFitnessSelectedMoreOften_Double(selection, 40);
+		validateHigherFitnessSelectedMoreOften_Integer(selection, 40);
 		
 		LinearRankSelection selectionUniform = new LinearRankSelection(1.0);
 		
@@ -1167,11 +1169,15 @@ public class SelectionOperatorTests {
 	}
 	
 	private void validateHigherFitnessSelectedMoreOften_Double(SelectionOperator selection) {
+		validateHigherFitnessSelectedMoreOften_Double(selection, 20);
+	}
+	
+	private void validateHigherFitnessSelectedMoreOften_Double(SelectionOperator selection, int selectSize) {
 		// This part of the test attempts to confirm that greater weight is placed on
 		// higher fitness population members. A sporadic failure is not necessarily a 
 		// real failure, but it should fail with low probability.
 		PopFitVectorDouble pf_d = new PopFitVectorDouble(10);
-		int[] selected = new int[20];
+		int[] selected = new int[selectSize];
 		selection.select(pf_d, selected);
 		int countLarger = 0;
 		for (int i = 0; i < selected.length; i++) {
@@ -1180,7 +1186,7 @@ public class SelectionOperatorTests {
 		assertTrue(countLarger > selected.length/2);
 		
 		pf_d.reverse();
-		selected = new int[20];
+		selected = new int[selectSize];
 		selection.select(pf_d, selected);
 		countLarger = 0;
 		for (int i = 0; i < selected.length; i++) {
@@ -1190,11 +1196,15 @@ public class SelectionOperatorTests {
 	}
 	
 	private void validateHigherFitnessSelectedMoreOften_Integer(SelectionOperator selection) {
+		validateHigherFitnessSelectedMoreOften_Integer(selection, 20);
+	}
+	
+	private void validateHigherFitnessSelectedMoreOften_Integer(SelectionOperator selection, int selectSize) {
 		// This part of the test attempts to confirm that greater weight is placed on
 		// higher fitness population members. A sporadic failure is not necessarily a 
 		// real failure, but it should fail with low probability.
 		PopFitVectorInteger pf_int = new PopFitVectorInteger(10);
-		int[] selected = new int[20];
+		int[] selected = new int[selectSize];
 		selection.select(pf_int, selected);
 		int countLarger = 0;
 		for (int i = 0; i < selected.length; i++) {
@@ -1203,7 +1213,7 @@ public class SelectionOperatorTests {
 		assertTrue(countLarger > selected.length/2);
 		
 		pf_int.reverse();
-		selected = new int[20];
+		selected = new int[selectSize];
 		selection.select(pf_int, selected);
 		countLarger = 0;
 		for (int i = 0; i < selected.length; i++) {


### PR DESCRIPTION
## Summary
Bumped rho-mu to 1.2.0. Also edited test cases for linear rank selection.
