### PR TITLE
Bump rho-mu and jpt versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ the minimum supported Java to Java 17. See details below for other breaking chan
 
 ### Dependencies
 * Bumped core from 1.1.0 to 2.1.0 (breaking change).
+* Bumped rho-mu from 1.2.0 to 2.3.0 (breaking change).
+* Bumped jpt from 3.3.0 to 4.0.0 (breaking change).
 
 ### CI/CD
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,12 @@
 		<dependency>
 			<groupId>org.cicirello</groupId>
 			<artifactId>jpt</artifactId>
-			<version>3.3.0</version>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cicirello</groupId>
 			<artifactId>rho-mu</artifactId>
-			<version>1.2.0</version>
+			<version>2.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cicirello</groupId>


### PR DESCRIPTION
## Summary
The following needed to be done simultaneously:
* Bumped rho-mu from 1.2.0 to 2.3.0 (breaking change).
* Bumped jpt from 3.3.0 to 4.0.0 (breaking change).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
