### PR TITLE
Updated documentation website workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
         base-url-path: https://chips-n-salsa.cicirello.org/
         path-to-root: gh-pages
         user-defined-block: |
+          <meta name="monetization" content="$ilp.uphold.com/RHNKxp4ZeLNE">
           <link rel="icon" href="/images/favicon48.png" sizes="16x16 32x32 48x48" type="image/png">
           <link rel="icon" href="/images/favicon96.png" sizes="96x96" type="image/png">
           <link rel="icon" href="/images/favicon144.png" sizes="144x144" type="image/png">


### PR DESCRIPTION
## Summary
Updated the documentation website workflow to inject web monetization meta tag into the head of each javadoc page.