### PR TITLE
Added FitnessShifter  class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-07-28
+## [Unreleased] - 2022-07-29
 
 ### Added
 * SigmaScaling class, implementing sigma scaling.
+* FitnessShifter class for use in combination with fitness-weighted selection operators to shift all fitnesses
+  such that minimum fitness is 1 at the time of selection (e.g., deals with negative fitnesses, etc).
 
 ### Changed
 

--- a/src/main/java/org/cicirello/search/evo/FitnessShifter.java
+++ b/src/main/java/org/cicirello/search/evo/FitnessShifter.java
@@ -1,0 +1,109 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.evo;
+
+import org.cicirello.search.concurrent.Splittable;
+
+/**
+ * <p>FitnessShifter wraps another SelectionOperator, shifting all 
+ * fitness values by the minimum fitness minus one, such that the least fit population member's
+ * transformed fitness is equal to 1, with the wrapped SelectionOperator than performing
+ * selection using the transformed fitnesses. One benefit is that this provides a mechanism
+ * for dealing with negative fitnesses in the case of a fitness proportional selection operator.</p>
+ *
+ * <p>The fitness, f<sub>i</sub>, of population member i is transformed as follows:
+ * f'<sub>i</sub> = f<sub>i</sub> - f<sub>min</sub> + 1, where f<sub>min</sub> is the minimum
+ * fitness in the population.</p>
+ *
+ * <p>The intended use-case is to use in combination with a fitness weighted selection
+ * operator, such as {@link FitnessProportionalSelection}, {@link StochasticUniversalSampling},
+ * {@link BiasedFitnessProportionalSelection}, or {@link BiasedStochasticUniversalSampling}.
+ * Here is an example of how to instantiate an instance of a selection operator using SigmaScaling:</p> 
+ *
+ * <pre><code>
+ * SelectionOperator selection = new FitnessShifter(new FitnessProportionalSelection());
+ * </code></pre>
+ * 
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class FitnessShifter implements SelectionOperator {
+	
+	private final SelectionOperator selection;
+	
+	/**
+	 * Constructs a new FitnessShifter object, to transform fitness values so that minumum
+	 * fitness is 1.
+	 *
+	 * @param selection The selection operator.
+	 */
+	public FitnessShifter(SelectionOperator selection) {
+		this.selection = selection;
+	}
+	
+	@Override
+	public void select(PopulationFitnessVector.Integer fitnesses, int[] selected) {
+		selection.select(PopulationFitnessVector.Integer.of(shift(fitnesses.toIntArray())), selected);
+	}
+	
+	@Override
+	public void select(PopulationFitnessVector.Double fitnesses, int[] selected) {
+		selection.select(PopulationFitnessVector.Double.of(shift(fitnesses.toDoubleArray())), selected);
+	}
+	
+	@Override
+	public void init(int generations) {
+		selection.init(generations);
+	}
+	
+	@Override
+	public FitnessShifter split() {
+		return new FitnessShifter(selection.split());
+	}
+	
+	private int[] shift(int[] f) {
+		int adjustment = f[0];
+		for (int i = 1; i < f.length; i++) {
+			if (f[i] < adjustment) {
+				adjustment = f[i];
+			}
+		}
+		adjustment--;
+		for (int i = 0; i < f.length; i++) {
+			f[i] -= adjustment;
+		}
+		return f;
+	}
+	
+	private double[] shift(double[] f) {
+		double adjustment = f[0];
+		for (int i = 1; i < f.length; i++) {
+			if (f[i] < adjustment) {
+				adjustment = f[i];
+			}
+		}
+		adjustment -= 1.0;
+		for (int i = 0; i < f.length; i++) {
+			f[i] -= adjustment;
+		}
+		return f;
+	}
+}

--- a/src/test/java/org/cicirello/search/evo/FitnessShifterTests.java
+++ b/src/test/java/org/cicirello/search/evo/FitnessShifterTests.java
@@ -1,0 +1,188 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JUnit test cases for FitnessShifter.
+ */
+public class FitnessShifterTests {
+	
+	@Test
+	public void testAllPositiveIntegers() {
+		int[] fitnesses = {8, 6, 4, 5, 9, 10};
+		int[] expected = {5, 3, 1, 2, 6, 7};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Integer pop = PopulationFitnessVector.Integer.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertTrue(wrapped.selectIntegerCalled);
+		assertFalse(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+		
+		shifter.init(101);
+		assertTrue(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+		FitnessShifter shifter2 = shifter.split();
+		assertTrue(wrapped.splitCalled);
+		assertNotSame(shifter, shifter2);
+	}
+	
+	@Test
+	public void testAllNegativeIntegers() {
+		int[] fitnesses = {-8, -6, -4, -5, -9, -10};
+		int[] expected = {3, 5, 7, 6, 2, 1};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Integer pop = PopulationFitnessVector.Integer.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertTrue(wrapped.selectIntegerCalled);
+		assertFalse(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+	}
+	
+	@Test
+	public void testMixedIntegers() {
+		int[] fitnesses = {-8, 6, -4, -5, 9, 10};
+		int[] expected = {1, 15, 5, 4, 18, 19};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Integer pop = PopulationFitnessVector.Integer.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertTrue(wrapped.selectIntegerCalled);
+		assertFalse(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+	}
+	
+	@Test
+	public void testAllPositiveDoubles() {
+		double[] fitnesses = {8, 6, 4, 5, 9, 10};
+		double[] expected = {5, 3, 1, 2, 6, 7};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Double pop = PopulationFitnessVector.Double.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertFalse(wrapped.selectIntegerCalled);
+		assertTrue(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+		
+		shifter.init(101);
+		assertTrue(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+		FitnessShifter shifter2 = shifter.split();
+		assertTrue(wrapped.splitCalled);
+		assertNotSame(shifter, shifter2);
+	}
+	
+	@Test
+	public void testAllNegativeDoubles() {
+		double[] fitnesses = {-8, -6, -4, -5, -9, -10};
+		double[] expected = {3, 5, 7, 6, 2, 1};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Double pop = PopulationFitnessVector.Double.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertFalse(wrapped.selectIntegerCalled);
+		assertTrue(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+	}
+	
+	@Test
+	public void testMixedDoubles() {
+		double[] fitnesses = {-8, 6, -4, -5, 9, 10};
+		double[] expected = {1, 15, 5, 4, 18, 19};
+		TestSelection wrapped = new TestSelection(expected);
+		FitnessShifter shifter = new FitnessShifter(wrapped);
+		PopulationFitnessVector.Double pop = PopulationFitnessVector.Double.of(fitnesses);
+		int[] selected = new int[fitnesses.length];
+		shifter.select(pop, selected);
+		assertFalse(wrapped.selectIntegerCalled);
+		assertTrue(wrapped.selectDoubleCalled);
+		assertFalse(wrapped.initCalled);
+		assertFalse(wrapped.splitCalled);
+	}
+	
+	
+	private static class TestSelection implements SelectionOperator {
+		
+		private double[] expectedD;
+		private int[] expectedInt;
+		private boolean selectDoubleCalled;
+		private boolean selectIntegerCalled;
+		private boolean initCalled;
+		private boolean splitCalled;
+		
+		public TestSelection(double[] expectedD) {
+			this.expectedD = expectedD;
+		}
+		
+		public TestSelection(int[] expectedInt) {
+			this.expectedInt = expectedInt;
+		}
+		
+		private TestSelection(TestSelection other) {
+			this.expectedD = other.expectedD;
+			this.expectedInt = other.expectedInt;
+		}
+		
+		@Override
+		public void select(PopulationFitnessVector.Integer fitnesses, int[] selected) {
+			assertEquals(expectedInt.length, fitnesses.size());
+			for (int i = 0; i < expectedInt.length; i++) {
+				assertEquals(expectedInt[i], fitnesses.getFitness(i));
+			}
+			selectIntegerCalled = true;
+		}
+		
+		@Override
+		public void select(PopulationFitnessVector.Double fitnesses, int[] selected) {
+			assertEquals(expectedD.length, fitnesses.size());
+			for (int i = 0; i < expectedD.length; i++) {
+				assertEquals(expectedD[i], fitnesses.getFitness(i));
+			}
+			selectDoubleCalled = true;
+		}
+		
+		@Override
+		public void init(int generations) {
+			initCalled = true;
+			assertEquals(101, generations);
+		}
+		
+		@Override
+		public TestSelection split() {
+			splitCalled = true;
+			return new TestSelection(this);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Added FitnessShifter class for use in combination with fitness-weighted selection operators to shift all fitnesses such that minimum fitness is 1 at the time of selection (e.g., deals with negative fitnesses, etc).

## Closing Issues
Closes #439 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
