### PR TITLE
Deprecated shifted fitness variations of fitness weighed selection operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Deprecated
+* ShiftedFitnessProportionalSelection, replaced by combination of FitnessShifter with FitnessProportionalSelection.
+* ShiftedStochasticUniversalSampling, replaced by combination of FitnessShifter with StochasticUniversalSampling.
+* BiasedShiftedFitnessProportionalSelection, replaced by combination of FitnessShifter with BiasedFitnessProportionalSelection.
+* BiasedShiftedStochasticUniversalSampling, replaced by combination of FitnessShifter with BiasedStochasticUniversalSampling.
 
 ### Removed
 

--- a/src/main/java/org/cicirello/search/evo/BiasedFitnessProportionalSelection.java
+++ b/src/main/java/org/cicirello/search/evo/BiasedFitnessProportionalSelection.java
@@ -36,7 +36,8 @@ package org.cicirello.search.evo;
  *
  * <p><b>This selection operator requires positive fitness values. Behavior is undefined if any 
  * fitness values are less than or equal to 0.</b> If your fitness values may be negative,
- * use {@link BiasedShiftedFitnessProportionalSelection} instead.</p>
+ * you can use {@link FitnessShifter}, which transforms fitness values such that minimum fitness
+ * equals 1.</p>
  *
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M lg N), assuming the bias function has a constant runtime.</p>

--- a/src/main/java/org/cicirello/search/evo/BiasedShiftedFitnessProportionalSelection.java
+++ b/src/main/java/org/cicirello/search/evo/BiasedShiftedFitnessProportionalSelection.java
@@ -46,9 +46,13 @@ package org.cicirello.search.evo;
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M lg N), assuming the bias function has a constant runtime.</p>
  *
+ * @deprecated Instead of this class, you should use a combination of {@link FitnessShifter} and 
+ * {@link BiasedFitnessProportionalSelection}. This class is scheduled for removal in release 6.0.0.
+ *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
+@Deprecated
 public final class BiasedShiftedFitnessProportionalSelection extends FitnessProportionalSelection {
 	
 	private final FitnessBiasFunction bias;

--- a/src/main/java/org/cicirello/search/evo/BiasedShiftedStochasticUniversalSampling.java
+++ b/src/main/java/org/cicirello/search/evo/BiasedShiftedStochasticUniversalSampling.java
@@ -58,9 +58,13 @@ package org.cicirello.search.evo;
  * O(N + M), which includes the need to generate only a single random double, and O(M) ints. This assumes
  * that the bias function has a constant runtime.</p>
  *
+ * @deprecated Instead of this class, you should use a combination of {@link FitnessShifter} and 
+ * {@link BiasedStochasticUniversalSampling}. This class is scheduled for removal in release 6.0.0.
+ *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
+@Deprecated
 public final class BiasedShiftedStochasticUniversalSampling extends StochasticUniversalSampling {
 	
 	private final FitnessBiasFunction bias;

--- a/src/main/java/org/cicirello/search/evo/BiasedStochasticUniversalSampling.java
+++ b/src/main/java/org/cicirello/search/evo/BiasedStochasticUniversalSampling.java
@@ -48,7 +48,8 @@ package org.cicirello.search.evo;
  *
  * <p><b>This selection operator requires positive fitness values. Behavior is undefined if any 
  * fitness values are less than or equal to 0.</b> If your fitness values may be negative,
- * use {@link BiasedShiftedStochasticUniversalSampling} instead.</p>
+ * you can use {@link FitnessShifter}, which transforms fitness values such that minimum fitness
+ * equals 1.</p>
  *
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M), which includes the need to generate only a single random double, and O(M) ints. This assumes

--- a/src/main/java/org/cicirello/search/evo/FitnessProportionalSelection.java
+++ b/src/main/java/org/cicirello/search/evo/FitnessProportionalSelection.java
@@ -33,7 +33,8 @@ package org.cicirello.search.evo;
  *
  * <p><b>This selection operator requires positive fitness values. Behavior is undefined if any 
  * fitness values are less than or equal to 0.</b> If your fitness values may be negative,
- * use {@link ShiftedFitnessProportionalSelection} instead.</p>
+ * you can use {@link FitnessShifter}, which transforms fitness values such that minimum fitness
+ * equals 1.</p>
  *
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M lg N).</p>

--- a/src/main/java/org/cicirello/search/evo/ShiftedFitnessProportionalSelection.java
+++ b/src/main/java/org/cicirello/search/evo/ShiftedFitnessProportionalSelection.java
@@ -42,9 +42,13 @@ package org.cicirello.search.evo;
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M lg N).</p>
  *
+ * @deprecated Instead of this class, you should use a combination of {@link FitnessShifter} and 
+ * {@link FitnessProportionalSelection}. This class is scheduled for removal in release 6.0.0.
+ *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
+@Deprecated
 public final class ShiftedFitnessProportionalSelection extends FitnessProportionalSelection {
 	
 	/**

--- a/src/main/java/org/cicirello/search/evo/ShiftedStochasticUniversalSampling.java
+++ b/src/main/java/org/cicirello/search/evo/ShiftedStochasticUniversalSampling.java
@@ -51,9 +51,13 @@ package org.cicirello.search.evo;
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M), which includes the need to generate only a single random double, and O(M) ints.</p>
  *
+ * @deprecated Instead of this class, you should use a combination of {@link FitnessShifter} and 
+ * {@link StochasticUniversalSampling}. This class is scheduled for removal in release 6.0.0.
+ *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
+@Deprecated
 public final class ShiftedStochasticUniversalSampling extends StochasticUniversalSampling {
 	
 	/**

--- a/src/main/java/org/cicirello/search/evo/StochasticUniversalSampling.java
+++ b/src/main/java/org/cicirello/search/evo/StochasticUniversalSampling.java
@@ -45,7 +45,8 @@ import org.cicirello.math.rand.RandomIndexer;
  *
  * <p><b>This selection operator requires positive fitness values. Behavior is undefined if any 
  * fitness values are less than or equal to 0.</b> If your fitness values may be negative,
- * use {@link ShiftedStochasticUniversalSampling} instead.</p>
+ * you can use {@link FitnessShifter}, which transforms fitness values such that minimum fitness
+ * equals 1.</p>
  *
  * <p>The runtime to select M population members from a population of size N is
  * O(N + M), which includes the need to generate only a single random double, and O(M) random ints.</p>

--- a/src/test/java/org/cicirello/search/evo/GATests.java
+++ b/src/test/java/org/cicirello/search/evo/GATests.java
@@ -50,7 +50,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 			0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -73,7 +73,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -86,7 +86,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -111,7 +111,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -134,7 +134,7 @@ public class GATests {
 				1.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -147,7 +147,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -160,7 +160,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -173,7 +173,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -186,7 +186,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -212,7 +212,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -232,7 +232,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -255,7 +255,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -268,7 +268,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -293,7 +293,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -316,7 +316,7 @@ public class GATests {
 				1.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -329,7 +329,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -342,7 +342,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -355,7 +355,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -368,7 +368,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -394,7 +394,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -415,7 +415,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -437,7 +437,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -449,7 +449,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 	}
@@ -467,7 +467,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -489,7 +489,7 @@ public class GATests {
 				1.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -501,7 +501,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -513,7 +513,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -525,7 +525,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -537,7 +537,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -567,7 +567,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -589,7 +589,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -601,7 +601,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 	}
@@ -619,7 +619,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -641,7 +641,7 @@ public class GATests {
 				1.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -653,7 +653,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -665,7 +665,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -677,7 +677,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -689,7 +689,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -722,7 +722,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -744,7 +744,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -757,7 +757,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -770,7 +770,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -796,7 +796,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -809,7 +809,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -829,7 +829,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -851,7 +851,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -864,7 +864,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -877,7 +877,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -903,7 +903,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -916,7 +916,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -937,7 +937,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()	
+			new FitnessShifter(new FitnessProportionalSelection())	
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -958,7 +958,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -970,7 +970,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -982,7 +982,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -1006,7 +1006,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 	}
@@ -1024,7 +1024,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.0,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -1045,7 +1045,7 @@ public class GATests {
 				0.0,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -1057,7 +1057,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -1069,7 +1069,7 @@ public class GATests {
 				M,
 				new SinglePointCrossover(),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -1081,7 +1081,7 @@ public class GATests {
 				M,
 				null,
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -1114,7 +1114,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.5,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -1142,7 +1142,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.5,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -1169,7 +1169,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.5,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -1195,7 +1195,7 @@ public class GATests {
 			M,
 			new SinglePointCrossover(),
 				0.5,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());

--- a/src/test/java/org/cicirello/search/evo/MutationOnlyGATests.java
+++ b/src/test/java/org/cicirello/search/evo/MutationOnlyGATests.java
@@ -47,7 +47,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -68,7 +68,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -79,7 +79,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -102,7 +102,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -123,7 +123,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				1.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -134,7 +134,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -145,7 +145,7 @@ public class MutationOnlyGATests {
 				null,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -156,7 +156,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				(FitnessFunction.Double<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -178,7 +178,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -196,7 +196,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -217,7 +217,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -228,7 +228,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -251,7 +251,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -272,7 +272,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				1.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -283,7 +283,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -294,7 +294,7 @@ public class MutationOnlyGATests {
 				null,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -305,7 +305,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				(FitnessFunction.Integer<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -327,7 +327,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -346,7 +346,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -366,7 +366,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -376,7 +376,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 	}
@@ -392,7 +392,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -412,7 +412,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				1.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -422,7 +422,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -432,7 +432,7 @@ public class MutationOnlyGATests {
 				null,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -442,7 +442,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				(FitnessFunction.Double<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -468,7 +468,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -488,7 +488,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -498,7 +498,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 	}
@@ -514,7 +514,7 @@ public class MutationOnlyGATests {
 			new AllZerosInitializer(L),
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -534,7 +534,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				1.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -544,7 +544,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -554,7 +554,7 @@ public class MutationOnlyGATests {
 				null,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -564,7 +564,7 @@ public class MutationOnlyGATests {
 				new AllZerosInitializer(L),
 				(FitnessFunction.Integer<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -593,7 +593,7 @@ public class MutationOnlyGATests {
 			L,
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -613,7 +613,7 @@ public class MutationOnlyGATests {
 				L,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -624,7 +624,7 @@ public class MutationOnlyGATests {
 				L,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -635,7 +635,7 @@ public class MutationOnlyGATests {
 				L,
 				(FitnessFunction.Double<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -657,7 +657,7 @@ public class MutationOnlyGATests {
 				L,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -675,7 +675,7 @@ public class MutationOnlyGATests {
 			L,
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection(),
+			new FitnessShifter(new FitnessProportionalSelection()),
 			tracker
 		);
 		assertTrue(tracker == ga.getProgressTracker());
@@ -695,7 +695,7 @@ public class MutationOnlyGATests {
 				L,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -706,7 +706,7 @@ public class MutationOnlyGATests {
 				L,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -717,7 +717,7 @@ public class MutationOnlyGATests {
 				L,
 				(FitnessFunction.Integer<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				tracker
 			)
 		);
@@ -739,7 +739,7 @@ public class MutationOnlyGATests {
 				L,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection(),
+				new FitnessShifter(new FitnessProportionalSelection()),
 				null
 			)
 		);
@@ -758,7 +758,7 @@ public class MutationOnlyGATests {
 			L,
 			new InverseCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()	
+			new FitnessShifter(new FitnessProportionalSelection())	
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -777,7 +777,7 @@ public class MutationOnlyGATests {
 				L,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -787,7 +787,7 @@ public class MutationOnlyGATests {
 				L,
 				new InverseCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -797,7 +797,7 @@ public class MutationOnlyGATests {
 				L,
 				(FitnessFunction.Double<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 
@@ -823,7 +823,7 @@ public class MutationOnlyGATests {
 			L,
 			new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 			M,
-			new ShiftedFitnessProportionalSelection()
+			new FitnessShifter(new FitnessProportionalSelection())
 		);
 		ProgressTracker<BitVector> tracker = ga.getProgressTracker();
 		assertTrue(problem == ga.getProblem());
@@ -842,7 +842,7 @@ public class MutationOnlyGATests {
 				L,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				0.0,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownIllegal = assertThrows( 
@@ -852,7 +852,7 @@ public class MutationOnlyGATests {
 				L,
 				new NegativeIntegerCostFitnessFunction<BitVector>(problem),
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		NullPointerException thrownNull = assertThrows( 
@@ -862,7 +862,7 @@ public class MutationOnlyGATests {
 				L,
 				(FitnessFunction.Integer<BitVector>)null,
 				M,
-				new ShiftedFitnessProportionalSelection()
+				new FitnessShifter(new FitnessProportionalSelection())
 			)
 		);
 		thrownNull = assertThrows( 

--- a/src/test/java/org/cicirello/search/evo/SelectionOperatorTests.java
+++ b/src/test/java/org/cicirello/search/evo/SelectionOperatorTests.java
@@ -328,6 +328,7 @@ public class SelectionOperatorTests {
 	}
 	
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testShiftedFitnessProportionalSelection() {
 		ShiftedFitnessProportionalSelection selection = new ShiftedFitnessProportionalSelection();
 		validateIndexes_Double(selection);
@@ -360,6 +361,7 @@ public class SelectionOperatorTests {
 	}
 	
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testBiasedShiftedFitnessProportionalSelection() {
 		BiasedShiftedFitnessProportionalSelection selection = new BiasedShiftedFitnessProportionalSelection(x -> x*x);
 		validateIndexes_Double(selection);
@@ -402,6 +404,7 @@ public class SelectionOperatorTests {
 	}
 	
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testShiftedSUS() {
 		ShiftedStochasticUniversalSampling selection = new ShiftedStochasticUniversalSampling();
 		validateIndexes_Double(selection);
@@ -454,6 +457,7 @@ public class SelectionOperatorTests {
 	}
 	
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testBiasedShiftedSUS() {
 		BiasedShiftedStochasticUniversalSampling selection = new BiasedShiftedStochasticUniversalSampling(x -> x*x);
 		validateIndexes_Double(selection);


### PR DESCRIPTION
## Summary
Deprecated the following:
* ShiftedFitnessProportionalSelection, replaced by combination of FitnessShifter with FitnessProportionalSelection.
* ShiftedStochasticUniversalSampling, replaced by combination of FitnessShifter with StochasticUniversalSampling.
* BiasedShiftedFitnessProportionalSelection, replaced by combination of FitnessShifter with BiasedFitnessProportionalSelection.
* BiasedShiftedStochasticUniversalSampling, replaced by combination of FitnessShifter with BiasedStochasticUniversalSampling.

## Closing Issues
Closes #443 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
