### PR TITLE
Fixed bug in test cases for OX and NWOX

### DIFF
--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -33,7 +33,7 @@ public class OrderingRelatedCrossoverTests {
 	@Test
 	public void testOX() {
 		OrderCrossover ox = new OrderCrossover();
-		for (int n = 1; n <= 32; n *= 2) {
+		for (int n = 1; n <= 64; n *= 2) {
 			Permutation p1 = new Permutation(n);
 			Permutation p2 = new Permutation(n);
 			Permutation parent1 = new Permutation(p1);
@@ -41,10 +41,12 @@ public class OrderingRelatedCrossoverTests {
 			ox.cross(parent1, parent2);
 			assertTrue(validPermutation(parent1));
 			assertTrue(validPermutation(parent2));
-			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-			int[] startAndEnd = findStartAndEnd(fixedPoints);
-			validateOrderingOX(parent1, p2, startAndEnd);
-			validateOrderingOX(parent2, p1, startAndEnd);
+			if (n >= 32) {
+				boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+				int[] startAndEnd = findStartAndEnd(fixedPoints);
+				validateOrderingOX(parent1, p2, startAndEnd);
+				validateOrderingOX(parent2, p1, startAndEnd);
+			}
 			assertSame(ox, ox.split());
 		}
 	}
@@ -52,7 +54,7 @@ public class OrderingRelatedCrossoverTests {
 	@Test
 	public void testNWOX() {
 		NonWrappingOrderCrossover nwox = new NonWrappingOrderCrossover();
-		for (int n = 1; n <= 32; n *= 2) {
+		for (int n = 1; n <= 64; n *= 2) {
 			Permutation p1 = new Permutation(n);
 			Permutation p2 = new Permutation(n);
 			Permutation parent1 = new Permutation(p1);
@@ -60,10 +62,12 @@ public class OrderingRelatedCrossoverTests {
 			nwox.cross(parent1, parent2);
 			assertTrue(validPermutation(parent1));
 			assertTrue(validPermutation(parent2));
-			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-			int[] startAndEnd = findStartAndEnd(fixedPoints);
-			validateOrderingNWOX(parent1, p2, startAndEnd);
-			validateOrderingNWOX(parent2, p1, startAndEnd);
+			if (n >= 32) {
+				boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+				int[] startAndEnd = findStartAndEnd(fixedPoints);
+				validateOrderingNWOX(parent1, p2, startAndEnd);
+				validateOrderingNWOX(parent2, p1, startAndEnd);
+			}
 			assertSame(nwox, nwox.split());
 		}
 	}


### PR DESCRIPTION
## Summary
Fixed bug in test cases for OX and NWOX. Impossible for test cases to know for sure which random cross region was selected by the operator. Test cases currently make best guess by finding the longest contiguous sequence of fixed points between children and parents. That is not guaranteed to be foolproof, and when it is not may lead to a false test case failure. The longer the length of the permutation, the less likely such false test failures will occur. Changed test cases to only do that check for permutation lengths 32 and 64 (and not the especially short permutations).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
