### PR TITLE
Added Uniform Order-Based Crossover (UOBX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Cycle Crossover (CX)
   * Order Crossover (OX)
   * Non-Wrapping Order Crossover (NWOX)
+  * Uniform Order-Based Crossover (UOBX)
 
 ### Changed
 

--- a/src/main/java/org/cicirello/search/operators/permutations/UniformOrderBasedCrossover.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/UniformOrderBasedCrossover.java
@@ -1,0 +1,124 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2022 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ * 
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.search.operators.permutations;
+
+import org.cicirello.search.operators.CrossoverOperator;
+import org.cicirello.permutations.Permutation;
+import org.cicirello.math.rand.RandomIndexer;
+import org.cicirello.util.IntegerList;
+
+/**
+ * <p>Implementation of uniform order-based crossover (UOBX). UOBX is controlled by a parameter U,
+ * which is the probability that an index is a fixed-point for children relative to parents (i.e.,
+ * that the children get the elements at those positions from the parents). Child c1
+ * gets the absolute positions of U*N elements on average from parent p1, where N is the permutation
+ * length, and c1 gets the relative positions of the remaining elements from parent p2. Likewise, child
+ * c2 gets the absolute positions of elements at those same chosen indexes from p2, with the relative 
+ * positions of the others coming from p1.</p>
+ *
+ * <p>Consider an example to illustrate. Let parent p1 = [3, 0, 6, 2, 5, 1, 4, 7] and parent
+ * p2 = [7, 6, 5, 4, 3, 2, 1, 0]. Consider U=0.5, and imagine in this hypothetical scenario that
+ * exactly half of the indexes were chosen, and that those 4 indexes are: 0, 3, 4, 6. Child c1 will
+ * get the elements at those indexes from p1, thus c1 begins with [3, x, x, 2, 5, x, 4, x]. The missing
+ * elements, 0, 1, 6, 7 will get their relative ordering from p2, and thus will be ordered as: 7, 6, 1, 0.
+ * In that order, they will fill into the open spots to derive: c1 = [3, 7, 6, 2, 5, 1, 4, 0]. Likewise,
+ * c2 will get the elements from indexes 0, 3, 4, and 6 from p2 to initialize as [7, x, x, 4, 3, x, 1, x].
+ * Its missing elements, 0, 2, 5, and 6 will get relative order from p1, and thus will be ordered
+ * 0, 6, 2, 5 to derive c2 = [7, 0, 6, 4, 3, 2, 1, 5].</p>
+ *
+ * <p>UOBX was introduced in the following paper:<br>
+ * Syswerda, G. Schedule Optimization using Genetic Algorithms. <i>Handbook of Genetic Algorithms</i>, 1991.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class UniformOrderBasedCrossover implements CrossoverOperator<Permutation> {
+	
+	private final double u;
+	
+	/**
+	 * Constructs a uniform order-based crossover (UOBX) operator, with a default U=0.5.
+	 */
+	public UniformOrderBasedCrossover() {
+		this(0.5);
+	}
+	
+	/**
+	 * Constructs a uniform order-based crossover (UOBX) operator.
+	 *
+	 * @param u The probability of an index being among the fixed-point positions.
+	 *
+	 * @throws IllegalArgumentException if u is less than or equal to 0.0, or if u is greater than
+	 * or equal to 1.0.
+	 */
+	public UniformOrderBasedCrossover(double u) {
+		if (u <= 0 || u >= 1.0) throw new IllegalArgumentException("u must be: 0.0 < u < 1.0");
+		this.u = u;
+	}
+	
+	@Override
+	public void cross(Permutation c1, Permutation c2) {
+		c1.apply( 
+			(raw1, raw2) -> {
+				boolean[] mask = RandomIndexer.arrayMask(raw1.length, u);
+				boolean[] in1 = new boolean[raw1.length];
+				boolean[] in2 = new boolean[raw1.length];
+				int orderedCount = 0;
+				for (int k = 0; k < mask.length; k++) {
+					if (mask[k]) {
+						in1[raw1[k]] = true;
+						in2[raw2[k]] = true;
+					} else {
+						orderedCount++;
+					}
+				}
+				
+				if (orderedCount > 0) {
+					IntegerList list1 = new IntegerList(orderedCount);
+					IntegerList list2 = new IntegerList(orderedCount);
+					for (int k = 0; k < raw1.length; k++) {
+						if (!in2[raw1[k]]) {
+							list1.add(raw1[k]);
+						}
+						if (!in1[raw2[k]]) {
+							list2.add(raw2[k]);
+						}
+					}
+					int w = 0;
+					for (int k = 0; k < mask.length; k++) {
+						if (!mask[k]) {
+							raw1[k] = list2.get(w);
+							raw2[k] = list1.get(w);
+							w++;
+						}
+					}
+				}
+			},
+			c2
+		);
+	}
+	
+	@Override
+	public UniformOrderBasedCrossover split() {
+		// doesn't maintain any mutable state, so safe to return this
+		return this;
+	}
+}

--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -72,6 +72,122 @@ public class OrderingRelatedCrossoverTests {
 		}
 	}
 	
+	@Test
+	public void testUOBXIdenticalParents() {
+		UniformOrderBasedCrossover uobx = new UniformOrderBasedCrossover();
+		for (int n = 1; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(p1);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			assertEquals(p1, parent1);
+			assertEquals(p2, parent2);
+		}
+		assertSame(uobx, uobx.split());
+	}
+	
+	@Test
+	public void testUOBXNear0U() {
+		UniformOrderBasedCrossover uobx = new UniformOrderBasedCrossover(Math.ulp(0.0));
+		for (int n = 1; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			// the near 0 u should essentially swap the parents
+			// other than a low probability statistical anomaly
+			assertEquals(p2, parent1);
+			assertEquals(p1, parent2);
+		}
+	}
+	
+	@Test
+	public void testUOBXNear1U() {
+		UniformOrderBasedCrossover uobx = new UniformOrderBasedCrossover(1.0-Math.ulp(1.0));
+		for (int n = 1; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			// the near 1.0 u should essentially keep all of the parents
+			// other than a low probability statistical anomaly
+			assertEquals(p1, parent1);
+			assertEquals(p2, parent2);
+		}
+	}
+	
+	@Test
+	public void testUOBXTypicalCase() {
+		UniformOrderBasedCrossover uobx = new UniformOrderBasedCrossover();
+		for (int n = 1; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			assertTrue(validPermutation(parent1));
+			assertTrue(validPermutation(parent2));
+			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+			validateOrderingUOBX(parent1, p2, fixedPoints);
+			validateOrderingUOBX(parent2, p1, fixedPoints);
+		}
+		
+		uobx = new UniformOrderBasedCrossover(0.25);
+		for (int n = 8; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			assertTrue(validPermutation(parent1));
+			assertTrue(validPermutation(parent2));
+			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+			validateOrderingUOBX(parent1, p2, fixedPoints);
+			validateOrderingUOBX(parent2, p1, fixedPoints);
+		}
+		
+		uobx = new UniformOrderBasedCrossover(0.75);
+		for (int n = 8; n <= 32; n*= 2) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			uobx.cross(parent1, parent2);
+			assertTrue(validPermutation(parent1));
+			assertTrue(validPermutation(parent2));
+			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+			validateOrderingUOBX(parent1, p2, fixedPoints);
+			validateOrderingUOBX(parent2, p1, fixedPoints);
+		}
+	}
+	
+	@Test
+	public void testExceptionsUOBX() {
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UniformOrderBasedCrossover(0.0)
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> new UniformOrderBasedCrossover(1.0)
+		);
+	}
+	
+	private void validateOrderingUOBX(Permutation child, Permutation order, boolean[] fixedPoints) {
+		int[] inv = order.getInverse();
+		int last = -1;
+		for (int i = 0; i < fixedPoints.length; i++) {
+			if (!fixedPoints[i]) {
+				if (last >= 0) {
+					assertTrue(inv[child.get(i)] > inv[child.get(last)]);
+				}
+				last = i;
+			}
+		}
+	}
 	
 	private void validateOrderingOX(Permutation child, Permutation order, int[] startAndEnd) {
 		int[] inv = order.getInverse();


### PR DESCRIPTION
## Summary
Added Uniform Order-Based Crossover (UOBX), a crossover operator for permutations.

## Closing Issues
Closes #456 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
