### PR TITLE
Improved test cases for OX and NWOX crossover operators

### DIFF
--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -54,21 +54,27 @@ public class OrderingRelatedCrossoverTests {
 		}
 		assertSame(ox, ox.split());
 		final int n = 2000;
-		Permutation p1 = new Permutation(n);
-		Permutation p2 = new Permutation(n);
-		Permutation parent1 = new Permutation(p1);
-		Permutation parent2 = new Permutation(p2);
-		ox.cross(parent1, parent2);
-		assertTrue(validPermutation(parent1));
-		assertTrue(validPermutation(parent2));
-		boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-		int[] startAndEnd = findStartAndEnd(fixedPoints);
+		final int RUNS = 4;
+		boolean passed = false;
+		for (int run = 0; run < RUNS && !passed; run++) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			ox.cross(parent1, parent2);
+			assertTrue(validPermutation(parent1));
+			assertTrue(validPermutation(parent2));
+			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+			int[] startAndEnd = findStartAndEnd(fixedPoints);
+			passed = validateOrderingOX(parent1, p2, startAndEnd) && validateOrderingOX(parent2, p1, startAndEnd);
+		}
 		// The following may on infrequent occasions exhibit a false failure.
 		// This is due to the above findStartAndEnd heuristically guessing what
 		// the random cross region was. I believe the probability of a false
-		// failure is approximately 1/n. Rerun if fails.
-		assertTrue(validateOrderingOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
-		assertTrue(validateOrderingOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		// failure is very approximately (2/n)^RUNS, which for 3 runs of n=2000 is about 1 in 1000000000. Rerun if fails.
+		assertTrue(passed, "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		//assertTrue(validateOrderingOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		//assertTrue(validateOrderingOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 	}
 	
 	@Test
@@ -94,21 +100,27 @@ public class OrderingRelatedCrossoverTests {
 		}
 		assertSame(nwox, nwox.split());
 		final int n = 2000;
-		Permutation p1 = new Permutation(n);
-		Permutation p2 = new Permutation(n);
-		Permutation parent1 = new Permutation(p1);
-		Permutation parent2 = new Permutation(p2);
-		nwox.cross(parent1, parent2);
-		assertTrue(validPermutation(parent1));
-		assertTrue(validPermutation(parent2));
-		boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-		int[] startAndEnd = findStartAndEnd(fixedPoints);
+		final int RUNS = 4;
+		boolean passed = false;
+		for (int run = 0; run < RUNS && !passed; run++) {
+			Permutation p1 = new Permutation(n);
+			Permutation p2 = new Permutation(n);
+			Permutation parent1 = new Permutation(p1);
+			Permutation parent2 = new Permutation(p2);
+			nwox.cross(parent1, parent2);
+			assertTrue(validPermutation(parent1));
+			assertTrue(validPermutation(parent2));
+			boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+			int[] startAndEnd = findStartAndEnd(fixedPoints);
+			passed = validateOrderingNWOX(parent1, p2, startAndEnd) && validateOrderingNWOX(parent2, p1, startAndEnd);
+		}
 		// The following may on infrequent occasions exhibit a false failure.
 		// This is due to the above findStartAndEnd heuristically guessing what
 		// the random cross region was. I believe the probability of a false
-		// failure is approximately 1/n. Rerun if fails.
-		assertTrue(validateOrderingNWOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
-		assertTrue(validateOrderingNWOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		// failure is very approximately (2/n)^RUNS, which for 3 runs of n=2000 is about 1 in 1000000000. Rerun if fails.
+		assertTrue(passed, "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		//assertTrue(validateOrderingNWOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		//assertTrue(validateOrderingNWOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 	}
 	
 	@Test

--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -67,8 +67,8 @@ public class OrderingRelatedCrossoverTests {
 		// This is due to the above findStartAndEnd heuristically guessing what
 		// the random cross region was. I believe the probability of a false
 		// failure is approximately 1/n. Rerun if fails.
-		validateOrderingOX(parent1, p2, startAndEnd);
-		validateOrderingOX(parent2, p1, startAndEnd);
+		assertTrue(validateOrderingOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		assertTrue(validateOrderingOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 	}
 	
 	@Test
@@ -107,8 +107,8 @@ public class OrderingRelatedCrossoverTests {
 		// This is due to the above findStartAndEnd heuristically guessing what
 		// the random cross region was. I believe the probability of a false
 		// failure is approximately 1/n. Rerun if fails.
-		validateOrderingNWOX(parent1, p2, startAndEnd);
-		validateOrderingNWOX(parent2, p1, startAndEnd);
+		assertTrue(validateOrderingNWOX(parent1, p2, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+		assertTrue(validateOrderingNWOX(parent2, p1, startAndEnd), "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 	}
 	
 	@Test
@@ -243,30 +243,40 @@ public class OrderingRelatedCrossoverTests {
 		}
 	}
 	
-	private void validateOrderingOX(Permutation child, Permutation order, int[] startAndEnd) {
+	private boolean validateOrderingOX(Permutation child, Permutation order, int[] startAndEnd) {
 		int[] inv = order.getInverse();
+		boolean result = true;
 		for (int i = startAndEnd[1] + 2; i < inv.length; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(i)] > inv[child.get(i-1)];
+			//assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		for (int i = 1; i < startAndEnd[0]; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(i)] > inv[child.get(i-1)];
+			//assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		if (0 < startAndEnd[0] && inv.length-1 > startAndEnd[1]) {
-			assertTrue(inv[child.get(0)] > inv[child.get(inv.length-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(0)] > inv[child.get(inv.length-1)];
+			//assertTrue(inv[child.get(0)] > inv[child.get(inv.length-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
+		return result;
 	}
 	
-	private void validateOrderingNWOX(Permutation child, Permutation order, int[] startAndEnd) {
+	private boolean validateOrderingNWOX(Permutation child, Permutation order, int[] startAndEnd) {
 		int[] inv = order.getInverse();
+		boolean result = true;
 		for (int i = 1; i < startAndEnd[0]; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(i)] > inv[child.get(i-1)];
+			//assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		for (int i = startAndEnd[1] + 2; i < inv.length; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(i)] > inv[child.get(i-1)];
+			//assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		if (startAndEnd[0] - 1 >= 0 && startAndEnd[1] + 1 < inv.length) {
-			assertTrue(inv[child.get(startAndEnd[1] + 1)] > inv[child.get(startAndEnd[0] - 1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
+			result = result && inv[child.get(startAndEnd[1] + 1)] > inv[child.get(startAndEnd[0] - 1)];
+			//assertTrue(inv[child.get(startAndEnd[1] + 1)] > inv[child.get(startAndEnd[0] - 1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
+		return result;
 	}
 	
 	private int[] findStartAndEnd(boolean[] fixedPoints) {

--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -53,7 +53,7 @@ public class OrderingRelatedCrossoverTests {
 			}
 		}
 		assertSame(ox, ox.split());
-		final int n = 1000;
+		final int n = 2000;
 		Permutation p1 = new Permutation(n);
 		Permutation p2 = new Permutation(n);
 		Permutation parent1 = new Permutation(p1);
@@ -93,7 +93,7 @@ public class OrderingRelatedCrossoverTests {
 			}
 		}
 		assertSame(nwox, nwox.split());
-		final int n = 1000;
+		final int n = 2000;
 		Permutation p1 = new Permutation(n);
 		Permutation p2 = new Permutation(n);
 		Permutation parent1 = new Permutation(p1);

--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -44,15 +44,31 @@ public class OrderingRelatedCrossoverTests {
 				ox.cross(parent1, parent2);
 				assertTrue(validPermutation(parent1));
 				assertTrue(validPermutation(parent2));
-				if (n >= 32) {
-					boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-					int[] startAndEnd = findStartAndEnd(fixedPoints);
-					validateOrderingOX(parent1, p2, startAndEnd);
-					validateOrderingOX(parent2, p1, startAndEnd);
-				}
+				//if (n >= 32) {
+				//	boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+				//	int[] startAndEnd = findStartAndEnd(fixedPoints);
+				//	validateOrderingOX(parent1, p2, startAndEnd);
+				//	validateOrderingOX(parent2, p1, startAndEnd);
+				//}
 			}
-			assertSame(ox, ox.split());
 		}
+		assertSame(ox, ox.split());
+		final int n = 1000;
+		Permutation p1 = new Permutation(n);
+		Permutation p2 = new Permutation(n);
+		Permutation parent1 = new Permutation(p1);
+		Permutation parent2 = new Permutation(p2);
+		ox.cross(parent1, parent2);
+		assertTrue(validPermutation(parent1));
+		assertTrue(validPermutation(parent2));
+		boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+		int[] startAndEnd = findStartAndEnd(fixedPoints);
+		// The following may on infrequent occasions exhibit a false failure.
+		// This is due to the above findStartAndEnd heuristically guessing what
+		// the random cross region was. I believe the probability of a false
+		// failure is approximately 1/n. Rerun if fails.
+		validateOrderingOX(parent1, p2, startAndEnd);
+		validateOrderingOX(parent2, p1, startAndEnd);
 	}
 	
 	@Test
@@ -67,15 +83,32 @@ public class OrderingRelatedCrossoverTests {
 				nwox.cross(parent1, parent2);
 				assertTrue(validPermutation(parent1));
 				assertTrue(validPermutation(parent2));
-				if (n >= 32) {
-					boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
-					int[] startAndEnd = findStartAndEnd(fixedPoints);
-					validateOrderingNWOX(parent1, p2, startAndEnd);
-					validateOrderingNWOX(parent2, p1, startAndEnd);
-				}
+				
+				boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+				//int[] startAndEnd = findStartAndEnd(fixedPoints);
+				// Deliberately using UOBX validation here to verify non-fixed points
+				// follow relative ordering property only.
+				validateOrderingUOBX(parent1, p2, fixedPoints);
+				validateOrderingUOBX(parent2, p1, fixedPoints);
 			}
-			assertSame(nwox, nwox.split());
 		}
+		assertSame(nwox, nwox.split());
+		final int n = 1000;
+		Permutation p1 = new Permutation(n);
+		Permutation p2 = new Permutation(n);
+		Permutation parent1 = new Permutation(p1);
+		Permutation parent2 = new Permutation(p2);
+		nwox.cross(parent1, parent2);
+		assertTrue(validPermutation(parent1));
+		assertTrue(validPermutation(parent2));
+		boolean[] fixedPoints = findFixedPoints(parent1, parent2, p1, p2);
+		int[] startAndEnd = findStartAndEnd(fixedPoints);
+		// The following may on infrequent occasions exhibit a false failure.
+		// This is due to the above findStartAndEnd heuristically guessing what
+		// the random cross region was. I believe the probability of a false
+		// failure is approximately 1/n. Rerun if fails.
+		validateOrderingNWOX(parent1, p2, startAndEnd);
+		validateOrderingNWOX(parent2, p1, startAndEnd);
 	}
 	
 	@Test
@@ -213,26 +246,26 @@ public class OrderingRelatedCrossoverTests {
 	private void validateOrderingOX(Permutation child, Permutation order, int[] startAndEnd) {
 		int[] inv = order.getInverse();
 		for (int i = startAndEnd[1] + 2; i < inv.length; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)]);
+			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		for (int i = 1; i < startAndEnd[0]; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)]);
+			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		if (0 < startAndEnd[0] && inv.length-1 > startAndEnd[1]) {
-			assertTrue(inv[child.get(0)] > inv[child.get(inv.length-1)]);
+			assertTrue(inv[child.get(0)] > inv[child.get(inv.length-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 	}
 	
 	private void validateOrderingNWOX(Permutation child, Permutation order, int[] startAndEnd) {
 		int[] inv = order.getInverse();
 		for (int i = 1; i < startAndEnd[0]; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)]);
+			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		for (int i = startAndEnd[1] + 2; i < inv.length; i++) {
-			assertTrue(inv[child.get(i)] > inv[child.get(i-1)]);
+			assertTrue(inv[child.get(i)] > inv[child.get(i-1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 		if (startAndEnd[0] - 1 >= 0 && startAndEnd[1] + 1 < inv.length) {
-			assertTrue(inv[child.get(startAndEnd[1] + 1)] > inv[child.get(startAndEnd[0] - 1)]);
+			assertTrue(inv[child.get(startAndEnd[1] + 1)] > inv[child.get(startAndEnd[0] - 1)], "This may infrequently result in a false failure because test case heuristically guesses where the random cross region was. Rerun if fails.");
 		}
 	}
 	


### PR DESCRIPTION
## Summary
The OX and NWOX crossover operators involve choosing a random cross region. The test cases heuristically guess (from the result) what that cross region was. The operators don't store it for use afterwards, so there is no way to determine definitively. If the test case's heuristic guess is wrong, then there may be a false test failure. i.e., the operator may have done the right thing, but the test case fails because it believes the random cross region was different than it actually was. In this PR, the test cases are improved to significantly reduce the probability of one of these false failures. I believe one of these false failures should now be approximately a 1 in 1000000 to 1 in 1000000000 case. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
