### PR TITLE
Added test cases for permutation crossover operators

### DIFF
--- a/src/test/java/org/cicirello/search/operators/permutations/CycleCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/CycleCrossoverTests.java
@@ -30,6 +30,26 @@ import org.cicirello.permutations.distance.CycleDistance;
  */
 public class CycleCrossoverTests {
 	
+	// Insert @Test here to activate during testing to visually inspect cross results
+	public void visuallyInspectCrossResult() {
+		int reps = 3;
+		CycleCrossover cx = new CycleCrossover();
+		for (int i = 0; i < reps; i++) {
+			Permutation p1 = new Permutation(10);
+			Permutation p2 = new Permutation(10);
+			
+			Permutation child1 = new Permutation(p1);
+			Permutation child2 = new Permutation(p2);
+			cx.cross(child1, child2);
+			System.out.println("CX Result");
+			System.out.println("Parent 1: " + p1);
+			System.out.println("Parent 2: " + p2);
+			System.out.println("Child 1 : " + child1);
+			System.out.println("Child 2 : " + child2);
+			System.out.println();
+		}			
+	}
+	
 	@Test
 	public void testIdenticalPermutations() {
 		CycleCrossover cross = new CycleCrossover();

--- a/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/OrderingRelatedCrossoverTests.java
@@ -32,6 +32,48 @@ public class OrderingRelatedCrossoverTests {
 	
 	private final static int NUM_SAMPLES = 5;
 	
+	// Insert @Test here to activate during testing to visually inspect cross results
+	public void visuallyInspectCrossResult() {
+		int reps = 3;
+		OrderCrossover ox = new OrderCrossover();
+		NonWrappingOrderCrossover nwox = new NonWrappingOrderCrossover();
+		UniformOrderBasedCrossover uobx = new UniformOrderBasedCrossover();
+		for (int i = 0; i < reps; i++) {
+			Permutation p1 = new Permutation(10);
+			Permutation p2 = new Permutation(10);
+			
+			Permutation child1 = new Permutation(p1);
+			Permutation child2 = new Permutation(p2);
+			ox.cross(child1, child2);
+			System.out.println("OX Result");
+			System.out.println("Parent 1: " + p1);
+			System.out.println("Parent 2: " + p2);
+			System.out.println("Child 1 : " + child1);
+			System.out.println("Child 2 : " + child2);
+			System.out.println();
+			
+			child1 = new Permutation(p1);
+			child2 = new Permutation(p2);
+			nwox.cross(child1, child2);
+			System.out.println("NWOX Result");
+			System.out.println("Parent 1: " + p1);
+			System.out.println("Parent 2: " + p2);
+			System.out.println("Child 1 : " + child1);
+			System.out.println("Child 2 : " + child2);
+			System.out.println();
+			
+			child1 = new Permutation(p1);
+			child2 = new Permutation(p2);
+			uobx.cross(child1, child2);
+			System.out.println("UOBX Result");
+			System.out.println("Parent 1: " + p1);
+			System.out.println("Parent 2: " + p2);
+			System.out.println("Child 1 : " + child1);
+			System.out.println("Child 2 : " + child2);
+			System.out.println();
+		}			
+	}
+	
 	@Test
 	public void testOX() {
 		OrderCrossover ox = new OrderCrossover();

--- a/src/test/java/org/cicirello/search/operators/permutations/PMXAndRelatedTests.java
+++ b/src/test/java/org/cicirello/search/operators/permutations/PMXAndRelatedTests.java
@@ -29,6 +29,26 @@ import org.cicirello.permutations.Permutation;
  */
 public class PMXAndRelatedTests {
 	
+	// Insert @Test here to activate during testing to visually inspect cross results
+	public void visuallyInspectCrossResult() {
+		int reps = 3;
+		PartiallyMatchedCrossover pmx = new PartiallyMatchedCrossover();
+		for (int i = 0; i < reps; i++) {
+			Permutation p1 = new Permutation(10);
+			Permutation p2 = new Permutation(10);
+			
+			Permutation child1 = new Permutation(p1);
+			Permutation child2 = new Permutation(p2);
+			pmx.cross(child1, child2);
+			System.out.println("PMX Result");
+			System.out.println("Parent 1: " + p1);
+			System.out.println("Parent 2: " + p2);
+			System.out.println("Child 1 : " + child1);
+			System.out.println("Child 2 : " + child2);
+			System.out.println();
+		}			
+	}
+	
 	@Test
 	public void testInternalPMX() {
 		PartiallyMatchedCrossover pmx = new PartiallyMatchedCrossover();


### PR DESCRIPTION
## Summary
Added optional test cases for permutation crossover operators. Specifically, added a few tests in a deactivated state (i.e., no `@Test` annotation) that when activated output the results of the permutation crossover operators on small sample permutations to enable visually, manually, inspecting. The existing tests are all automated, including attempting to confirm not only valid permutations as result, but also that the specific behavior of the implemented crossover operator is as defined. These deactivated, manual tests are in place as an added mechanism to ensure correct behavior, and not just valid results, since these operators are rather complex.

These are really a run one time kind of thing, but kept in test cases as a record, and to be available to run again if any thing changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
