### PR TITLE
Improved ahead-of-time jitpack snapshot builds

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Request master-SNAPSHOT from JitPack
       run: |
         # timeout in 30 seconds to avoid waiting for build
-        curl -s -m 30 https://jitpack.io/org/cicirello/chips-n-salsa/master-SNAPSHOT/ || true
+        curl -s -m 30 https://jitpack.io/org/cicirello/chips-n-salsa/master-SNAPSHOT/maven-metadata.xml || true


### PR DESCRIPTION
## Summary
Improved jitpack-build.yml workflow for ahead-of-time jitpack snapshot builds by curling the maven-metadata.xml rather than the directory of the snapshot.

## Closing Issues
Closes #494 
