### PR TITLE
Option to constrain result of uniform mutation to an interval

### DIFF
--- a/src/main/java/org/cicirello/search/operators/reals/UndoableUniformMutation.java
+++ b/src/main/java/org/cicirello/search/operators/reals/UndoableUniformMutation.java
@@ -111,6 +111,30 @@ public class UndoableUniformMutation<T extends RealValued> extends AbstractUndoa
 	}
 	
 	/**
+	 * Creates a Uniform mutation operator, such that the mutate method
+	 * constrains each mutated real value to lie in the interval [lowerBound, upperBound].
+	 *
+	 * @param radius The radius parameter of the Uniform.
+	 * @param lowerBound A lower bound on the result of a mutation.
+	 * @param upperBound An upper bound on the result of a mutation.
+	 *
+	 * @param <T> The specific RealValued type.
+	 * @return A Uniform mutation operator.
+	 */
+	public static <T extends RealValued> UndoableUniformMutation<T> createUniformMutation(double radius, double lowerBound, double upperBound) {
+		if (upperBound < lowerBound) throw new IllegalArgumentException("upperBound must be at least lowerBound");
+		return new UndoableUniformMutation<T>(
+			radius,
+			(old, param) -> {
+				double mutated = old + ThreadLocalRandom.current().nextDouble(-param, param);
+				if (mutated <= lowerBound) return lowerBound;
+				if (mutated >= upperBound) return upperBound;
+				return mutated;
+			}
+		);
+	}
+	
+	/**
 	 * Create a Uniform mutation operator that supports the undo operation.  
 	 * @param radius The radius parameter of the Uniform mutation.
 	 * @param k The number of input variables that the {@link #mutate} 

--- a/src/main/java/org/cicirello/search/operators/reals/UniformMutation.java
+++ b/src/main/java/org/cicirello/search/operators/reals/UniformMutation.java
@@ -111,6 +111,30 @@ public class UniformMutation<T extends RealValued> extends AbstractRealMutation<
 	}
 	
 	/**
+	 * Creates a Uniform mutation operator, such that the mutate method
+	 * constrains each mutated real value to lie in the interval [lowerBound, upperBound].
+	 *
+	 * @param radius The radius parameter of the Uniform.
+	 * @param lowerBound A lower bound on the result of a mutation.
+	 * @param upperBound An upper bound on the result of a mutation.
+	 *
+	 * @param <T> The specific RealValued type.
+	 * @return A Uniform mutation operator.
+	 */
+	public static <T extends RealValued> UniformMutation<T> createUniformMutation(double radius, double lowerBound, double upperBound) {
+		if (upperBound < lowerBound) throw new IllegalArgumentException("upperBound must be at least lowerBound");
+		return new UniformMutation<T>(
+			radius,
+			(old, param) -> {
+				double mutated = old + ThreadLocalRandom.current().nextDouble(-param, param);
+				if (mutated <= lowerBound) return lowerBound;
+				if (mutated >= upperBound) return upperBound;
+				return mutated;
+			}
+		);
+	}
+	
+	/**
 	 * Create a Uniform mutation operator.  
 	 * @param radius The radius parameter of the Uniform mutation.
 	 * @param k The number of input variables that the {@link #mutate} 

--- a/src/test/java/org/cicirello/search/operators/reals/UniformMutationTests.java
+++ b/src/test/java/org/cicirello/search/operators/reals/UniformMutationTests.java
@@ -215,5 +215,131 @@ public class UniformMutationTests extends SharedTestRealMutationOps {
 			IllegalArgumentException.class,
 			() -> UndoableUniformMutation.createUniformMutation(1.0, 0.0)
 		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> UniformMutation.createUniformMutation(1.0, 2.0, 2.0 - Math.ulp(2.0))
+		);
+		thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> UndoableUniformMutation.createUniformMutation(1.0, 2.0, 2.0 - Math.ulp(2.0))
+		);
+	}
+	
+	@Test
+	public void testConstrainedUniformMutation() {
+		{
+			UniformMutation<RealValued> g1 = UniformMutation.createUniformMutation(1.0, -10.0, 10.0);
+			assertEquals(1.0, g1.get(0));
+			verifyMutate1(g1);
+			
+			UniformMutation<RealValued> g5 = UniformMutation.createUniformMutation(5.0, -10.0, 10.0);
+			assertEquals(5.0, g5.get(0));
+			verifyMutate1(g5);
+			
+			UniformMutation<RealValued> g = UniformMutation.createUniformMutation(1.0, 2.0, 5.0);
+			RealVector r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			assertEquals(2.0, r.get(0));
+			assertEquals(2.0, r.get(1));
+			assertEquals(2.0, r.get(2));
+			assertTrue(r.get(3) >= 2.0 && r.get(3) <= 5.0);
+			assertTrue(r.get(4) >= 2.0 && r.get(4) <= 5.0);
+			assertEquals(5.0, r.get(5));
+			assertEquals(5.0, r.get(6));
+			assertEquals(5.0, r.get(7));
+			g = UniformMutation.createUniformMutation(1.0, 4.0, 4.0);
+			r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			for (int i = 0; i < 7; i++) {
+				assertEquals(4.0, r.get(i));
+			}
+		}
+		// copy
+		{
+			UniformMutation<RealValued> g1 = UniformMutation.createUniformMutation(1.0, -10.0, 10.0).copy();
+			assertEquals(1.0, g1.get(0));
+			verifyMutate1(g1);
+			
+			UniformMutation<RealValued> g5 = UniformMutation.createUniformMutation(5.0, -10.0, 10.0).copy();
+			assertEquals(5.0, g5.get(0));
+			verifyMutate1(g5);
+			
+			UniformMutation<RealValued> g = UniformMutation.createUniformMutation(1.0, 2.0, 5.0).copy();
+			RealVector r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			assertEquals(2.0, r.get(0));
+			assertEquals(2.0, r.get(1));
+			assertEquals(2.0, r.get(2));
+			assertTrue(r.get(3) >= 2.0 && r.get(3) <= 5.0);
+			assertTrue(r.get(4) >= 2.0 && r.get(4) <= 5.0);
+			assertEquals(5.0, r.get(5));
+			assertEquals(5.0, r.get(6));
+			assertEquals(5.0, r.get(7));
+			g = UniformMutation.createUniformMutation(1.0, 4.0, 4.0).copy();
+			r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			for (int i = 0; i < 7; i++) {
+				assertEquals(4.0, r.get(i));
+			}
+		}
+		// split
+		{
+			UniformMutation<RealValued> g1 = UniformMutation.createUniformMutation(1.0, -10.0, 10.0).split();
+			assertEquals(1.0, g1.get(0));
+			verifyMutate1(g1);
+			
+			UniformMutation<RealValued> g5 = UniformMutation.createUniformMutation(5.0, -10.0, 10.0).split();
+			assertEquals(5.0, g5.get(0));
+			verifyMutate1(g5);
+			
+			UniformMutation<RealValued> g = UniformMutation.createUniformMutation(1.0, 2.0, 5.0).split();
+			RealVector r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			assertEquals(2.0, r.get(0));
+			assertEquals(2.0, r.get(1));
+			assertEquals(2.0, r.get(2));
+			assertTrue(r.get(3) >= 2.0 && r.get(3) <= 5.0);
+			assertTrue(r.get(4) >= 2.0 && r.get(4) <= 5.0);
+			assertEquals(5.0, r.get(5));
+			assertEquals(5.0, r.get(6));
+			assertEquals(5.0, r.get(7));
+			g = UniformMutation.createUniformMutation(1.0, 4.0, 4.0).split();
+			r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+			g.mutate(r);
+			for (int i = 0; i < 7; i++) {
+				assertEquals(4.0, r.get(i));
+			}
+		}
+	}
+	
+	@Test
+	public void testUndoableConstrainedUniformMutation() {
+		UndoableUniformMutation<RealValued> g1 = UndoableUniformMutation.createUniformMutation(1.0, -10.0, 10.0);
+		assertEquals(1.0, g1.get(0));
+		verifyMutate1(g1);
+		verifyUndo(g1);
+		
+		UndoableUniformMutation<RealValued> g5 = UndoableUniformMutation.createUniformMutation(5.0, -10.0, 10.0);
+		assertEquals(5.0, g5.get(0));
+		verifyMutate1(g5);
+		verifyUndo(g5);
+		
+		UndoableUniformMutation<RealValued> g = UndoableUniformMutation.createUniformMutation(1.0, 2.0, 5.0);
+		RealVector r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+		g.mutate(r);
+		assertEquals(2.0, r.get(0));
+		assertEquals(2.0, r.get(1));
+		assertEquals(2.0, r.get(2));
+		assertTrue(r.get(3) >= 2.0 && r.get(3) <= 5.0);
+		assertTrue(r.get(4) >= 2.0 && r.get(4) <= 5.0);
+		assertEquals(5.0, r.get(5));
+		assertEquals(5.0, r.get(6));
+		assertEquals(5.0, r.get(7));
+		g = UndoableUniformMutation.createUniformMutation(1.0, 4.0, 4.0);
+		r = new RealVector(new double[] {-1000, -100, -50, 0.0, 3.0, 50, 100, 1000});
+		g.mutate(r);
+		for (int i = 0; i < 7; i++) {
+			assertEquals(4.0, r.get(i));
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Added a factory method in Uniform mutation operator classes (for real-valued representations) that constrains result to an interval.

## Closing Issues
Closes #513 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
