### PR TITLE
Replaced deprecated use of set-output in deployment workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Get the release version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
 
     - name: Set up JDK 17 for deploy to OSSRH
       uses: actions/setup-java@v3


### PR DESCRIPTION
## Summary
Replaced deprecated use of set-output in deployment workflow

## Closing Issues
Closes #535 
