### PR TITLE
Configuration of maven-shade-plugin fixed to suppress generation of dependency-reduced pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-11-14
+## [Unreleased] - 2022-11-17
 
 ### Added
 * AdaptiveEvolutionaryAlgorithm class: An implementation of an evolutionary algorithm with control 
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Configuration of maven-shade-plugin fixed to suppress generation of dependency-reduced pom to avoid 
+  breaking transitive dependencies for the regular jar of the library.
 
 ### Dependencies
 * Bump core from 2.2.2 to 2.4.3

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,7 @@
 				<configuration>
 					<shadedArtifactAttached>true</shadedArtifactAttached>
 					<shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
 					<filters>
 						<filter>
 							<artifact>*:*</artifact>
@@ -334,5 +335,4 @@
 			</plugin>
 		</plugins>
 	</build>
-  
 </project>


### PR DESCRIPTION
## Summary
Configuration of maven-shade-plugin fixed to suppress generation of dependency-reduced pom to avoid breaking transitive dependencies for the regular jar of the library.

## Closing Issues
Closes #545 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
