### PR TITLE
Fixed SolutionCostPair.compareTo and added missing equals and hashCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Fixed double comparison in SolutionCostPair.compareTo(SolutionCostPair).
+* Added missing equals and hashCode methods to SolutionCostPair.
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/SolutionCostPair.java
+++ b/src/main/java/org/cicirello/search/SolutionCostPair.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -129,9 +129,25 @@ public final class SolutionCostPair<T extends Copyable<T>>
    */
   @Override
   public int compareTo(SolutionCostPair<T> other) {
-    if (containsIntCost) return cost - other.cost;
-    if (costD < other.costD) return -1;
-    if (costD > other.costD) return 1;
-    return 0;
+    return containsIntCost ? cost - other.cost : Double.compare(costD, other.costD);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof SolutionCostPair) {
+      @SuppressWarnings("unchecked")
+      SolutionCostPair<T> casted = (SolutionCostPair<T>) other;
+      return containsIntCost == casted.containsIntCost
+          && isKnownOptimal == casted.isKnownOptimal
+          && compareTo(casted) == 0
+          && solution.equals(casted.solution);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = containsIntCost ? cost : Double.hashCode(costD);
+    return 31 * h + solution.hashCode();
   }
 }

--- a/src/test/java/org/cicirello/search/SolutionCostPairTests.java
+++ b/src/test/java/org/cicirello/search/SolutionCostPairTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -67,6 +67,8 @@ public class SolutionCostPairTests {
         new SolutionCostPair<TestCopyable>(new TestCopyable(5), 3, false);
     SolutionCostPair<TestCopyable> p6 =
         new SolutionCostPair<TestCopyable>(new TestCopyable(6), 7, false);
+    SolutionCostPair<TestCopyable> pEqual =
+        new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5, false);
     assertEquals(0, p1.compareTo(p2));
     assertEquals(0, p2.compareTo(p1));
     assertEquals(1, p1.compareTo(p3));
@@ -77,12 +79,51 @@ public class SolutionCostPairTests {
     assertEquals(-2, p5.compareTo(p1));
     assertEquals(-2, p1.compareTo(p6));
     assertEquals(2, p6.compareTo(p1));
+    assertEquals(0, p1.compareTo(pEqual));
+    assertEquals(0, pEqual.compareTo(p1));
+    assertEquals(p1, pEqual);
+    assertEquals(pEqual, p1);
+    assertEquals(p1.hashCode(), pEqual.hashCode());
+    assertNotEquals(p1, p2);
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p4);
+    assertNotEquals(p1, p5);
+    assertNotEquals(p1, p6);
+    assertNotEquals(p2, p1);
+    assertNotEquals(p2, p3);
+    assertNotEquals(p2, p4);
+    assertNotEquals(p2, p5);
+    assertNotEquals(p2, p6);
+    assertNotEquals(p3, p1);
+    assertNotEquals(p3, p2);
+    assertNotEquals(p3, p4);
+    assertNotEquals(p3, p5);
+    assertNotEquals(p3, p6);
+    assertNotEquals(p4, p1);
+    assertNotEquals(p4, p2);
+    assertNotEquals(p4, p3);
+    assertNotEquals(p4, p5);
+    assertNotEquals(p4, p6);
+    assertNotEquals(p5, p1);
+    assertNotEquals(p5, p2);
+    assertNotEquals(p5, p3);
+    assertNotEquals(p5, p4);
+    assertNotEquals(p5, p6);
+    assertNotEquals(p6, p1);
+    assertNotEquals(p6, p2);
+    assertNotEquals(p6, p3);
+    assertNotEquals(p6, p4);
+    assertNotEquals(p6, p5);
+    assertNotEquals(p1, "Hello");
+    assertNotEquals(p1, new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5.0, false));
+    assertNotEquals(p1, new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5, true));
     p1 = new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5.0, false);
     p2 = new SolutionCostPair<TestCopyable>(new TestCopyable(2), 5.0, false);
     p3 = new SolutionCostPair<TestCopyable>(new TestCopyable(3), 4.0, false);
     p4 = new SolutionCostPair<TestCopyable>(new TestCopyable(4), 6.0, false);
     p5 = new SolutionCostPair<TestCopyable>(new TestCopyable(5), 3.0, false);
     p6 = new SolutionCostPair<TestCopyable>(new TestCopyable(6), 7.0, false);
+    pEqual = new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5.0, false);
     assertEquals(0, p1.compareTo(p2));
     assertEquals(0, p2.compareTo(p1));
     assertEquals(1, p1.compareTo(p3));
@@ -93,6 +134,43 @@ public class SolutionCostPairTests {
     assertEquals(-1, p5.compareTo(p1));
     assertEquals(-1, p1.compareTo(p6));
     assertEquals(1, p6.compareTo(p1));
+    assertEquals(0, p1.compareTo(pEqual));
+    assertEquals(0, pEqual.compareTo(p1));
+    assertEquals(p1, pEqual);
+    assertEquals(pEqual, p1);
+    assertEquals(p1.hashCode(), pEqual.hashCode());
+    assertNotEquals(p1, p2);
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p4);
+    assertNotEquals(p1, p5);
+    assertNotEquals(p1, p6);
+    assertNotEquals(p2, p1);
+    assertNotEquals(p2, p3);
+    assertNotEquals(p2, p4);
+    assertNotEquals(p2, p5);
+    assertNotEquals(p2, p6);
+    assertNotEquals(p3, p1);
+    assertNotEquals(p3, p2);
+    assertNotEquals(p3, p4);
+    assertNotEquals(p3, p5);
+    assertNotEquals(p3, p6);
+    assertNotEquals(p4, p1);
+    assertNotEquals(p4, p2);
+    assertNotEquals(p4, p3);
+    assertNotEquals(p4, p5);
+    assertNotEquals(p4, p6);
+    assertNotEquals(p5, p1);
+    assertNotEquals(p5, p2);
+    assertNotEquals(p5, p3);
+    assertNotEquals(p5, p4);
+    assertNotEquals(p5, p6);
+    assertNotEquals(p6, p1);
+    assertNotEquals(p6, p2);
+    assertNotEquals(p6, p3);
+    assertNotEquals(p6, p4);
+    assertNotEquals(p6, p5);
+    assertNotEquals(p1, new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5, false));
+    assertNotEquals(p1, new SolutionCostPair<TestCopyable>(new TestCopyable(1), 5.0, true));
   }
 
   private static class TestCopyable implements Copyable<TestCopyable> {
@@ -111,6 +189,11 @@ public class SolutionCostPairTests {
     @Override
     public boolean equals(Object other) {
       return other != null && ((TestCopyable) other).a == a;
+    }
+
+    @Override
+    public int hashCode() {
+      return a;
     }
   }
 }


### PR DESCRIPTION
## Summary
* Fixed double comparison in SolutionCostPair.compareTo(SolutionCostPair).
* Added missing equals and hashCode methods to SolutionCostPair.

## Closing Issues
Closes #647 
Closes #648 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
