### PR TITLE
Fixed end of line chars when writing scheduling instances to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed double comparison in SolutionCostPair.compareTo(SolutionCostPair).
 * Added missing equals and hashCode methods to SolutionCostPair.
+* Fixed end of line characters when writing weighted static scheduling instances to file.
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetupsWriter.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedStaticSchedulingWithSetupsWriter.java
@@ -83,9 +83,9 @@ final class WeightedStaticSchedulingWithSetupsWriter {
     for (int i = 0; i < n; i++) {
       for (int j = 0; j < n; j++) {
         if (i == j) {
-          out.printf("%d %d %d\n", -1, j, s.getSetupTime(i, j));
+          out.printf("%d %d %d%n", -1, j, s.getSetupTime(i, j));
         } else {
-          out.printf("%d %d %d\n", i, j, s.getSetupTime(i, j));
+          out.printf("%d %d %d%n", i, j, s.getSetupTime(i, j));
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixed end of line characters when writing weighted static scheduling instances to file.

## Closing Issues
Closes #651 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
