### PR TITLE
Fixed constants that should be static fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed double comparison in SolutionCostPair.compareTo(SolutionCostPair).
 * Added missing equals and hashCode methods to SolutionCostPair.
 * Fixed end of line characters when writing weighted static scheduling instances to file.
+* WeightedStaticScheduling: fixed constants that should be static fields.
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedStaticScheduling.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedStaticScheduling.java
@@ -93,8 +93,8 @@ public final class WeightedStaticScheduling implements SingleMachineSchedulingPr
   private final int[] duedates;
   private final int[] weights;
 
-  private final int PROCESS_TIME_SPAN = MAX_PROCESS_TIME - MIN_PROCESS_TIME + 1;
-  private final int WEIGHT_SPAN = MAX_WEIGHT - MIN_WEIGHT + 1;
+  private static final int PROCESS_TIME_SPAN = MAX_PROCESS_TIME - MIN_PROCESS_TIME + 1;
+  private static final int WEIGHT_SPAN = MAX_WEIGHT - MIN_WEIGHT + 1;
 
   /**
    * Generates random single machine scheduling problem instances.


### PR DESCRIPTION
## Summary
WeightedStaticScheduling: fixed constants that should be static fields.

## Closing Issues
Closes #656 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
