### PR TITLE
Improved BlockInterchangeIterator.rollback()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * WeightedStaticScheduling: fixed constants that should be static fields.
 * Fixed potential int overflow in average computation in AbstractWeightedSelection.
 * Fixed potential int overflow in average computation in AbstractStochasticSampler.
+* Improved BlockInterchangeIterator.rollback().
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/operators/permutations/BlockInterchangeIterator.java
+++ b/src/main/java/org/cicirello/search/operators/permutations/BlockInterchangeIterator.java
@@ -132,6 +132,9 @@ final class BlockInterchangeIterator implements MutationIterator {
         case 4:
           p.swapBlocks(w, x, y, z);
           break;
+        default:
+          // deliberately empty: case when rolling back to original
+          break;
       }
     }
   }


### PR DESCRIPTION
## Summary
Improved BlockInterchangeIterator.rollback() by adding missing default case to switch statement. This was not a bug, strictly speaking, because the missing default case should do nothing. But the fact that it was missing may have lead one to question if something is not handled correctly. Added explicit default case that does nothing with a comment explaining why.

## Closing Issues
Closes #662 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
