### PR TITLE
Performance improvement to LargestCommonSubgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed potential int overflow in average computation in AbstractWeightedSelection.
 * Fixed potential int overflow in average computation in AbstractStochasticSampler.
 * Improved BlockInterchangeIterator.rollback().
+* Performance improvement to LargestCommonSubgraph
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/problems/LargestCommonSubgraph.java
+++ b/src/main/java/org/cicirello/search/problems/LargestCommonSubgraph.java
@@ -407,7 +407,7 @@ public final class LargestCommonSubgraph implements IntegerCostOptimizationProbl
    * Private internal class for use within the LargestCommonSubgraph class for representing
    * edges.
    */
-  private class InternalEdge {
+  private static class InternalEdge {
     private final int x;
     private final int y;
 


### PR DESCRIPTION
## Summary
Performance improvement to LargestCommonSubgraph: a private inner class is now static since it doesn't require reference to surrounding instance.

## Closing Issues
Closes #654 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
