### PR TITLE
Configured SpotBugs for false positive

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -11,4 +11,12 @@
 	<Class name="org.cicirello.search.concurrent.TimedParallelMultistarter" />
 	<Method name="getSearchHistory" />
   </Match>
+  
+  <!-- False positive: this really should be floating-point equality, as it is checking -->
+  <!-- if two RealValueInitializers have been configured exactly the same way. -->
+  <Match>
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
+	<Class name="org.cicirello.search.operators.reals.RealValueInitializer" />
+	<Method name="equals" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
Configured SpotBugs for false positive. The floating-point equality checks here are deliberate. The values are not result of be computed. They are settings. The equals method is checking if two instances have been configured exactly the same.

## Closing Issues
Closes #660 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
