### PR TITLE
SpotBugs: exclude false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed potential int overflow in average computation in AbstractWeightedSelection.
 * Fixed potential int overflow in average computation in AbstractStochasticSampler.
 * Improved BlockInterchangeIterator.rollback().
-* Performance improvement to LargestCommonSubgraph
+* Performance improvement to LargestCommonSubgraph.
 
 ### Dependencies
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -19,4 +19,10 @@
 	<Class name="org.cicirello.search.operators.reals.RealValueInitializer" />
 	<Method name="equals" />
   </Match>
+  
+  <!-- False positive: no additional state over superclass, which defines hashCode -->
+  <Match>
+    <Bug pattern="HE_EQUALS_NO_HASHCODE" />
+	<Class name="org.cicirello.search.operators.integers.UndoableRandomValueChangeMutation" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
SpotBugs: exclude false positive. The superclass defines hashCode appropriately, and the subclass doesn't add any additional state. All a hashCode method would do would be to call the superclass one,

## Closing Issues
Closes #649 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
