### PR TITLE
Removed unnecessary equals() and hashCode() methods from evolutionary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-08-04
+## [Unreleased] - 2023-08-05
 
 ### Added
 
@@ -23,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed potential int overflow in average computation in AbstractStochasticSampler.
 * Improved BlockInterchangeIterator.rollback().
 * Performance improvement to LargestCommonSubgraph.
-* Fixed symmetric issue with equals method of BoundMax and its superclass.
-* Fixed IntegerVectorInitializer.equals(). 
+* Removed unnecessary equals() and hashCode() methods from evolutionary operators.
 
 ### Dependencies
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -11,10 +11,4 @@
 	<Class name="org.cicirello.search.concurrent.TimedParallelMultistarter" />
 	<Method name="getSearchHistory" />
   </Match>
-  
-  <!-- False positives: superclass state based on new fields of subclass such that override of equals unnecessary -->
-  <Match>
-    <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" />
-	<Class name="org.cicirello.search.problems.BoundMax" />
-  </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -12,12 +12,6 @@
 	<Method name="getSearchHistory" />
   </Match>
   
-  <!-- False positives: superclass defines hashCode, subclass doesn't introduce new state -->
-  <Match>
-    <Bug pattern="HE_EQUALS_NO_HASHCODE" />
-	<Class name="org.cicirello.search.operators.integers.UndoableRandomValueChangeMutation" />
-  </Match>
-  
   <!-- False positives: superclass state based on new fields of subclass such that override of equals unnecessary -->
   <Match>
     <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" />

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -12,14 +12,6 @@
 	<Method name="getSearchHistory" />
   </Match>
   
-  <!-- False positive: this really should be floating-point equality, as it is checking -->
-  <!-- if two RealValueInitializers have been configured exactly the same way. -->
-  <Match>
-    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
-	<Class name="org.cicirello.search.operators.reals.RealValueInitializer" />
-	<Method name="equals" />
-  </Match>
-  
   <!-- False positives: superclass defines hashCode, subclass doesn't introduce new state -->
   <Match>
     <Bug pattern="HE_EQUALS_NO_HASHCODE" />

--- a/src/main/java/org/cicirello/search/ProgressTracker.java
+++ b/src/main/java/org/cicirello/search/ProgressTracker.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *

--- a/src/main/java/org/cicirello/search/operators/integers/IntegerValueInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/integers/IntegerValueInitializer.java
@@ -37,7 +37,7 @@ import org.cicirello.search.representations.SingleInteger;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class IntegerValueInitializer implements Initializer<SingleInteger> {
+public final class IntegerValueInitializer implements Initializer<SingleInteger> {
 
   private final int a;
   private final int b;
@@ -113,20 +113,6 @@ public class IntegerValueInitializer implements Initializer<SingleInteger> {
     return new IntegerValueInitializer(this);
   }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other == null || !(other instanceof IntegerValueInitializer)) {
-      return false;
-    }
-    IntegerValueInitializer i = (IntegerValueInitializer) other;
-    return a == i.a && b == i.b && min == i.min && max == i.max && bounded == i.bounded;
-  }
-
-  @Override
-  public int hashCode() {
-    return 31 * (31 * (31 * (31 * (31 + a) + b) + min) + max) + (bounded ? 1 : 0);
-  }
-
   /**
    * Internal class for representing the input to a univariate function, such that the input is an
    * integer, and where the input is bounded between a specified minimum and maximum value. If an
@@ -179,39 +165,6 @@ public class IntegerValueInitializer implements Initializer<SingleInteger> {
     @Override
     public BoundedInteger copy() {
       return new BoundedInteger(this);
-    }
-
-    private IntegerValueInitializer getOuterThis() {
-      return IntegerValueInitializer.this;
-    }
-    ;
-
-    /**
-     * Indicates whether some other object is "equal to" this one. To be equal, the other object
-     * must be of the same runtime type and contain the same value and bounds of the function input.
-     *
-     * @param other The other object to compare.
-     * @return true if other is not null, is of the same runtime type as this, and contains the same
-     *     function input value and bounds.
-     */
-    @Override
-    public boolean equals(Object other) {
-      if (other == null || !(other instanceof BoundedInteger) || !super.equals(other)) {
-        return false;
-      }
-      BoundedInteger a = (BoundedInteger) other;
-      return IntegerValueInitializer.this.min == a.getOuterThis().min
-          && IntegerValueInitializer.this.max == a.getOuterThis().max;
-    }
-
-    /**
-     * Returns a hash code value.
-     *
-     * @return a hash code value
-     */
-    @Override
-    public int hashCode() {
-      return 31 * (31 * (31 + super.hashCode()) + min) + max;
     }
   }
 }

--- a/src/main/java/org/cicirello/search/operators/integers/IntegerVectorInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/integers/IntegerVectorInitializer.java
@@ -20,7 +20,6 @@
 
 package org.cicirello.search.operators.integers;
 
-import java.util.Arrays;
 import org.cicirello.math.rand.EnhancedSplittableGenerator;
 import org.cicirello.search.internal.RandomnessFactory;
 import org.cicirello.search.operators.Initializer;
@@ -243,28 +242,6 @@ public class IntegerVectorInitializer implements Initializer<IntegerVector> {
     return new IntegerVectorInitializer(this);
   }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other == null || !getClass().equals(other.getClass())) {
-      return false;
-    }
-    IntegerVectorInitializer i = (IntegerVectorInitializer) other;
-    return x.length == i.x.length
-        && ((min == null && i.min == null)
-            || (Arrays.equals(min, i.min) && Arrays.equals(max, i.max)))
-        && Arrays.equals(a, i.a)
-        && Arrays.equals(b, i.b);
-  }
-
-  @Override
-  public int hashCode() {
-    int h = 31 * Arrays.hashCode(a) + Arrays.hashCode(b);
-    if (min != null) {
-      h = 31 * (31 * h + Arrays.hashCode(min)) + Arrays.hashCode(max);
-    }
-    return h;
-  }
-
   /**
    * Internal class for representing the input to a multivariate function, where the input
    * parameters are integers and are bounded between a specified minimum and maximum value. If an
@@ -335,50 +312,6 @@ public class IntegerVectorInitializer implements Initializer<IntegerVector> {
     @Override
     public MultiBoundedIntegerVector copy() {
       return new MultiBoundedIntegerVector(this);
-    }
-
-    private IntegerVectorInitializer getOuterThis() {
-      return IntegerVectorInitializer.this;
-    }
-    ;
-
-    /**
-     * Indicates whether some other object is "equal to" this one. To be equal, the other object
-     * must be of the same runtime type and contain the same values and bounds.
-     *
-     * @param other The other object to compare.
-     * @return true if other is not null, is of the same runtime type as this, and contains the same
-     *     values and bounds.
-     */
-    @Override
-    public boolean equals(Object other) {
-      if (other == null || !(other instanceof MultiBoundedIntegerVector) || !super.equals(other)) {
-        return false;
-      }
-      MultiBoundedIntegerVector b = (MultiBoundedIntegerVector) other;
-      return Arrays.equals(IntegerVectorInitializer.this.min, b.getOuterThis().min)
-          && Arrays.equals(IntegerVectorInitializer.this.max, b.getOuterThis().max);
-    }
-
-    /**
-     * Returns a hash code value.
-     *
-     * @return a hash code value
-     */
-    @Override
-    public int hashCode() {
-      int hash = 1;
-      for (int v : min) {
-        hash = 31 * hash + v;
-      }
-      for (int v : max) {
-        hash = 31 * hash + v;
-      }
-      int L = length();
-      for (int i = 0; i < L; i++) {
-        hash = 31 * hash + get(i);
-      }
-      return hash;
     }
   }
 }

--- a/src/main/java/org/cicirello/search/operators/integers/RandomValueChangeMutation.java
+++ b/src/main/java/org/cicirello/search/operators/integers/RandomValueChangeMutation.java
@@ -143,33 +143,6 @@ public class RandomValueChangeMutation<T extends IntegerValued> implements Mutat
     return new RandomValueChangeMutation<T>(this);
   }
 
-  /**
-   * Indicates whether some other object is equal to this one. The objects are equal if they are the
-   * same type of operator with the same parameters.
-   *
-   * @param other the object with which to compare
-   * @return true if and only if the objects are equal
-   */
-  @Override
-  public boolean equals(Object other) {
-    if (other == null || !(other instanceof RandomValueChangeMutation)) {
-      return false;
-    }
-    RandomValueChangeMutation m = (RandomValueChangeMutation) other;
-    return m.a == a && m.b == b && m.p == p && m.min_k == min_k;
-  }
-
-  /**
-   * Returns a hash code value for the object. This method is supported for the benefit of hash
-   * tables such as those provided by HashMap.
-   *
-   * @return a hash code value for this object
-   */
-  @Override
-  public int hashCode() {
-    return 31 * (31 * (31 * Double.hashCode(p) + a) + b) + min_k;
-  }
-
   /*
    * internal package-private helper in support of undo method in Undoable version of operator.
    */

--- a/src/main/java/org/cicirello/search/operators/integers/UndoableRandomValueChangeMutation.java
+++ b/src/main/java/org/cicirello/search/operators/integers/UndoableRandomValueChangeMutation.java
@@ -125,9 +125,4 @@ public final class UndoableRandomValueChangeMutation<T extends IntegerValued>
   public UndoableRandomValueChangeMutation<T> split() {
     return new UndoableRandomValueChangeMutation<T>(this);
   }
-
-  @Override
-  public boolean equals(Object other) {
-    return super.equals(other) && other instanceof UndoableRandomValueChangeMutation;
-  }
 }

--- a/src/main/java/org/cicirello/search/operators/reals/RealValueInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/reals/RealValueInitializer.java
@@ -112,19 +112,6 @@ public final class RealValueInitializer implements Initializer<SingleReal> {
     return new RealValueInitializer(this);
   }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other == null || !(other instanceof RealValueInitializer)) return false;
-    RealValueInitializer i = (RealValueInitializer) other;
-    return a == i.a && b == i.b && min == i.min && max == i.max;
-  }
-
-  @Override
-  public int hashCode() {
-    return 31 * (31 * (31 * (31 + Double.hashCode(a)) + Double.hashCode(b)) + Double.hashCode(min))
-        + Double.hashCode(max);
-  }
-
   /**
    * Internal class for representing the input to a univariate function, where the input is bounded
    * between a specified minimum and maximum value. If an attempt is made to set the value less than
@@ -176,41 +163,6 @@ public final class RealValueInitializer implements Initializer<SingleReal> {
     @Override
     public BoundedReal copy() {
       return new BoundedReal(this);
-    }
-
-    private RealValueInitializer getOuterThis() {
-      return RealValueInitializer.this;
-    }
-    ;
-
-    /**
-     * Indicates whether some other object is "equal to" this one. To be equal, the other object
-     * must be of the same runtime type and contain the same value and bounds of the parameters.
-     *
-     * @param other The other object to compare.
-     * @return true if other is not null, is of the same runtime type as this, and contains the same
-     *     parameter value and bounds.
-     */
-    @Override
-    public boolean equals(Object other) {
-      if (other == null || !(other instanceof BoundedReal) || !super.equals(other)) {
-        return false;
-      }
-      BoundedReal a = (BoundedReal) other;
-      return getOuterThis().equals(a.getOuterThis());
-    }
-
-    /**
-     * Returns a hash code value.
-     *
-     * @return a hash code value
-     */
-    @Override
-    public int hashCode() {
-      long bitsMin = Double.doubleToLongBits(min);
-      long bitsMax = Double.doubleToLongBits(max);
-      return 31 * (31 * (31 + super.hashCode()) + ((int) (bitsMin ^ (bitsMin >>> 32))))
-          + ((int) (bitsMax ^ (bitsMax >>> 32)));
     }
   }
 }

--- a/src/main/java/org/cicirello/search/operators/reals/RealVectorInitializer.java
+++ b/src/main/java/org/cicirello/search/operators/reals/RealVectorInitializer.java
@@ -20,7 +20,6 @@
 
 package org.cicirello.search.operators.reals;
 
-import java.util.Arrays;
 import org.cicirello.math.rand.EnhancedSplittableGenerator;
 import org.cicirello.search.internal.RandomnessFactory;
 import org.cicirello.search.operators.Initializer;
@@ -242,25 +241,6 @@ public final class RealVectorInitializer implements Initializer<RealVector> {
     return new RealVectorInitializer(this);
   }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other == null || !(other instanceof RealVectorInitializer)) return false;
-    RealVectorInitializer i = (RealVectorInitializer) other;
-    return ((min == null && i.min == null)
-            || (Arrays.equals(min, i.min) && Arrays.equals(max, i.max)))
-        && Arrays.equals(a, i.a)
-        && Arrays.equals(b, i.b);
-  }
-
-  @Override
-  public int hashCode() {
-    int h = 31 * Arrays.hashCode(a) + Arrays.hashCode(b);
-    if (min != null) {
-      h = 31 * (31 * h + Arrays.hashCode(min)) + Arrays.hashCode(max);
-    }
-    return h;
-  }
-
   /**
    * Internal class for representing the input to a multivariate function, where the input values
    * are bounded between a specified minimum and maximum value. If an attempt is made to set any of
@@ -333,50 +313,6 @@ public final class RealVectorInitializer implements Initializer<RealVector> {
     @Override
     public MultiBoundedRealVector copy() {
       return new MultiBoundedRealVector(this);
-    }
-
-    private RealVectorInitializer getOuterThis() {
-      return RealVectorInitializer.this;
-    }
-    ;
-
-    /**
-     * Indicates whether some other object is "equal to" this one. To be equal, the other object
-     * must be of the same runtime type and contain the same values and bounds.
-     *
-     * @param other The other object to compare.
-     * @return true if other is not null, is of the same runtime type as this, and contains the same
-     *     values and bounds.
-     */
-    @Override
-    public boolean equals(Object other) {
-      if (!super.equals(other)) return false;
-      MultiBoundedRealVector b = (MultiBoundedRealVector) other;
-      return getOuterThis().equals(b.getOuterThis());
-    }
-
-    /**
-     * Returns a hash code value for the function input object.
-     *
-     * @return a hash code value
-     */
-    @Override
-    public int hashCode() {
-      int hash = 1;
-      for (double v : min) {
-        long bitsV = Double.doubleToLongBits(v);
-        hash = 31 * hash + ((int) (bitsV ^ (bitsV >>> 32)));
-      }
-      for (double v : max) {
-        long bitsV = Double.doubleToLongBits(v);
-        hash = 31 * hash + ((int) (bitsV ^ (bitsV >>> 32)));
-      }
-      int L = length();
-      for (int i = 0; i < L; i++) {
-        long bitsV = Double.doubleToLongBits(get(i));
-        hash = 31 * hash + ((int) (bitsV ^ (bitsV >>> 32)));
-      }
-      return hash;
     }
   }
 }

--- a/src/main/java/org/cicirello/search/problems/BoundMax.java
+++ b/src/main/java/org/cicirello/search/problems/BoundMax.java
@@ -101,9 +101,4 @@ public final class BoundMax extends IntegerVectorInitializer
   public boolean isMinCost(int cost) {
     return cost == 0;
   }
-
-  /*
-   * Doesn't need to override equals and hashCode. Superclass implementation
-   * covers it for this class as well.
-   */
 }

--- a/src/test/java/org/cicirello/search/operators/integers/IntegerValuedInitializerTests.java
+++ b/src/test/java/org/cicirello/search/operators/integers/IntegerValuedInitializerTests.java
@@ -33,34 +33,6 @@ public class IntegerValuedInitializerTests {
   private final int NUM_SAMPLES = 100;
 
   @Test
-  public void testIntegerVectorInitializerEquals() {
-    IntegerVectorInitializer f = new IntegerVectorInitializer(2, 2, 4, 0, 8);
-    IntegerVectorInitializer g = new IntegerVectorInitializer(2, 2, 4, 0, 8);
-    IntegerVectorInitializer f1 = new IntegerVectorInitializer(2, 1, 4, 0, 8);
-    IntegerVectorInitializer f2 = new IntegerVectorInitializer(2, 2, 5, 0, 8);
-    IntegerVectorInitializer f3 = new IntegerVectorInitializer(2, 2, 4, 1, 8);
-    IntegerVectorInitializer f4 = new IntegerVectorInitializer(2, 2, 4, 0, 9);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-    assertNotEquals(f, f4);
-    assertNotEquals(f, null);
-    assertNotEquals(f, "hello");
-    f = new IntegerVectorInitializer(2, 2, 4);
-    g = new IntegerVectorInitializer(2, 2, 4);
-    f1 = new IntegerVectorInitializer(2, 1, 4);
-    f2 = new IntegerVectorInitializer(2, 2, 5);
-    f3 = new IntegerVectorInitializer(2, 2, 4, 0, 8);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-  }
-
-  @Test
   public void testBoundedIntegerEquals() {
     IntegerValueInitializer f = new IntegerValueInitializer(2, 3, 2, 2);
     SingleInteger g1 = f.createCandidateSolution();
@@ -102,14 +74,14 @@ public class IntegerValuedInitializerTests {
     f2 =
         new IntegerVectorInitializer(
             new int[] {2, 2}, new int[] {3, 3}, new int[] {2, 2}, new int[] {3, 3});
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
     f2 =
         new IntegerVectorInitializer(
             new int[] {2, 2}, new int[] {3, 3}, new int[] {0, 0}, new int[] {2, 2});
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
     assertFalse(g1.equals(null));
-    IntegerVectorInitializer nonMultiBound = new IntegerVectorInitializer(2, 2, 4, 0, 8);
-    assertFalse(g1.equals(nonMultiBound.createCandidateSolution()));
+    IntegerVectorInitializer nonMultiBound = new IntegerVectorInitializer(2, 2, 3, 0, 8);
+    assertEquals(g1, nonMultiBound.createCandidateSolution());
     IntegerVectorInitializer f3 =
         new IntegerVectorInitializer(
             new int[] {4, 4}, new int[] {5, 5}, new int[] {4, 4}, new int[] {4, 4});
@@ -234,9 +206,18 @@ public class IntegerValuedInitializerTests {
     int n = 1;
     IntegerVectorInitializer f = new IntegerVectorInitializer(n, a, b);
     IntegerVectorInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       IntegerVector g = f.createCandidateSolution();
+      assertTrue(g.get(0) < b && g.get(0) >= a);
+      assertEquals(theClass.getClass(), g.getClass());
+      assertEquals(n, g.length());
+      IntegerVector copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      IntegerVector g = fs.createCandidateSolution();
       assertTrue(g.get(0) < b && g.get(0) >= a);
       assertEquals(theClass.getClass(), g.getClass());
       assertEquals(n, g.length());
@@ -395,9 +376,23 @@ public class IntegerValuedInitializerTests {
     int max = 20;
     IntegerVectorInitializer f = new IntegerVectorInitializer(n, a, b, min, max);
     IntegerVectorInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       IntegerVector g = f.createCandidateSolution();
+      assertEquals(n, g.length());
+      assertTrue(g.get(0) < b && g.get(0) >= a);
+      g.set(0, min - 1);
+      assertEquals(min, g.get(0));
+      g.set(0, max + 1);
+      assertEquals(max, g.get(0));
+      g.set(0, 10);
+      assertEquals(10, g.get(0));
+      IntegerVector copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      IntegerVector g = fs.createCandidateSolution();
       assertEquals(n, g.length());
       assertTrue(g.get(0) < b && g.get(0) >= a);
       g.set(0, min - 1);

--- a/src/test/java/org/cicirello/search/operators/integers/IntegerValuedInitializerTests.java
+++ b/src/test/java/org/cicirello/search/operators/integers/IntegerValuedInitializerTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,28 +31,6 @@ public class IntegerValuedInitializerTests {
 
   // For tests involving randomness, number of test samples.
   private final int NUM_SAMPLES = 100;
-
-  @Test
-  public void testIntegerValueInitializerEquals() {
-    IntegerValueInitializer f = new IntegerValueInitializer(2, 3, 0, 5);
-    IntegerValueInitializer g = new IntegerValueInitializer(2, 3, 0, 5);
-    IntegerValueInitializer f1 = new IntegerValueInitializer(1, 3, 0, 5);
-    IntegerValueInitializer f2 = new IntegerValueInitializer(2, 4, 0, 5);
-    IntegerValueInitializer f3 = new IntegerValueInitializer(2, 3, -1, 5);
-    IntegerValueInitializer f4 = new IntegerValueInitializer(2, 3, 0, 6);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-    assertNotEquals(f, f4);
-    assertNotEquals(f, null);
-    assertNotEquals(new IntegerValueInitializer(0, 1, 0, 0), new IntegerValueInitializer(0, 1));
-    assertNotEquals(f, "hello");
-    f = new IntegerValueInitializer(0, 1, 0, 0);
-    g = new IntegerValueInitializer(0, 1);
-    assertNotEquals(f.hashCode(), g.hashCode());
-  }
 
   @Test
   public void testIntegerVectorInitializerEquals() {
@@ -88,7 +66,7 @@ public class IntegerValuedInitializerTests {
     SingleInteger g1 = f.createCandidateSolution();
     SingleInteger g2 = f.createCandidateSolution();
     SingleInteger h = new SingleInteger(2);
-    assertFalse(g1.equals(h));
+    assertTrue(g1.equals(h));
     assertEquals(g1, g2);
     assertEquals(g1.hashCode(), g2.hashCode());
     IntegerValueInitializer f2 = new IntegerValueInitializer(2, 3, 2, 2);
@@ -96,9 +74,9 @@ public class IntegerValuedInitializerTests {
     assertEquals(g1, g3);
     assertEquals(g1.hashCode(), g3.hashCode());
     f2 = new IntegerValueInitializer(2, 3, 2, 3);
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
     f2 = new IntegerValueInitializer(2, 3, 0, 2);
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
     assertFalse(g1.equals(null));
     f2 = new IntegerValueInitializer(4, 5, 2, 4);
     assertFalse(g1.equals(f2.createCandidateSolution()));
@@ -145,9 +123,21 @@ public class IntegerValuedInitializerTests {
     int b = 11;
     IntegerValueInitializer f = new IntegerValueInitializer(a, b);
     IntegerValueInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       SingleInteger g = f.createCandidateSolution();
+      assertTrue(g.get() < b && g.get() >= a);
+      assertEquals(theClass.getClass(), g.getClass());
+      SingleInteger copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+      g.set(a - 1);
+      assertEquals(a - 1, g.get());
+      g.set(b + 1);
+      assertEquals(b + 1, g.get());
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      SingleInteger g = fs.createCandidateSolution();
       assertTrue(g.get() < b && g.get() >= a);
       assertEquals(theClass.getClass(), g.getClass());
       SingleInteger copy = g.copy();

--- a/src/test/java/org/cicirello/search/operators/integers/RandomChangeTests.java
+++ b/src/test/java/org/cicirello/search/operators/integers/RandomChangeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,57 +32,6 @@ import org.junit.jupiter.api.*;
  * mutation for mutating integer valued representations.
  */
 public class RandomChangeTests {
-
-  @Test
-  public void testEquals() {
-    RandomValueChangeMutation<IntegerValued> r1 =
-        new RandomValueChangeMutation<IntegerValued>(1, 4);
-    RandomValueChangeMutation<IntegerValued> r2 =
-        new RandomValueChangeMutation<IntegerValued>(0, 4);
-    RandomValueChangeMutation<IntegerValued> r3 =
-        new RandomValueChangeMutation<IntegerValued>(1, 5);
-    RandomValueChangeMutation<IntegerValued> r4 = r1.split();
-    RandomValueChangeMutation<IntegerValued> r5 =
-        new RandomValueChangeMutation<IntegerValued>(1, 4, 0.0, 1);
-    RandomValueChangeMutation<IntegerValued> r6 =
-        new RandomValueChangeMutation<IntegerValued>(1, 4, 0.2, 1);
-    RandomValueChangeMutation<IntegerValued> r7 =
-        new RandomValueChangeMutation<IntegerValued>(1, 4, 0.0, 2);
-    assertEquals(r1, r4);
-    assertEquals(r1.hashCode(), r4.hashCode());
-    assertEquals(r1, r5);
-    assertEquals(r1.hashCode(), r5.hashCode());
-    assertNotEquals(r1, r2);
-    assertNotEquals(r1, r3);
-    assertNotEquals(r1, r6);
-    assertNotEquals(r1, r7);
-    assertFalse(r1.equals(null));
-    assertFalse(r1.equals("hello"));
-    UndoableRandomValueChangeMutation<IntegerValued> u1 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(1, 4);
-    UndoableRandomValueChangeMutation<IntegerValued> u2 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(0, 4);
-    UndoableRandomValueChangeMutation<IntegerValued> u3 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(1, 5);
-    UndoableRandomValueChangeMutation<IntegerValued> u4 = u1.split();
-    UndoableRandomValueChangeMutation<IntegerValued> u5 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(1, 4, 0.0, 1);
-    UndoableRandomValueChangeMutation<IntegerValued> u6 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(1, 4, 0.2, 1);
-    UndoableRandomValueChangeMutation<IntegerValued> u7 =
-        new UndoableRandomValueChangeMutation<IntegerValued>(1, 4, 0.0, 2);
-    // assertFalse(r1.equals(u1));
-    assertEquals(u1, u4);
-    assertEquals(u1.hashCode(), u4.hashCode());
-    assertEquals(u1, u5);
-    assertEquals(u1.hashCode(), u5.hashCode());
-    assertNotEquals(u1, u2);
-    assertNotEquals(u1, u3);
-    assertFalse(u1.equals(null));
-    assertNotEquals(u1, u6);
-    assertNotEquals(u1, u7);
-    assertFalse(u1.equals(r1));
-  }
 
   @Test
   public void testRandomValueChangeMutation() {

--- a/src/test/java/org/cicirello/search/operators/reals/RealValuedInitializerTests.java
+++ b/src/test/java/org/cicirello/search/operators/reals/RealValuedInitializerTests.java
@@ -36,34 +36,6 @@ public class RealValuedInitializerTests {
   private final double EPSILON = 1e-10;
 
   @Test
-  public void testRealVectorInitializerEquals() {
-    RealVectorInitializer f = new RealVectorInitializer(2, 2, 4, 0, 8);
-    RealVectorInitializer g = new RealVectorInitializer(2, 2, 4, 0, 8);
-    RealVectorInitializer f1 = new RealVectorInitializer(2, 1, 4, 0, 8);
-    RealVectorInitializer f2 = new RealVectorInitializer(2, 2, 5, 0, 8);
-    RealVectorInitializer f3 = new RealVectorInitializer(2, 2, 4, 1, 8);
-    RealVectorInitializer f4 = new RealVectorInitializer(2, 2, 4, 0, 9);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-    assertNotEquals(f, f4);
-    assertNotEquals(f, null);
-    assertNotEquals(f, "hello");
-    f = new RealVectorInitializer(2, 2, 4);
-    g = new RealVectorInitializer(2, 2, 4);
-    f1 = new RealVectorInitializer(2, 1, 4);
-    f2 = new RealVectorInitializer(2, 2, 5);
-    f3 = new RealVectorInitializer(2, 2, 4, 0, 8);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-  }
-
-  @Test
   public void testBoundedRealEquals() {
     RealValueInitializer f = new RealValueInitializer(2, 2 + Math.ulp(2), 2, 2);
     SingleReal g1 = f.createCandidateSolution();
@@ -120,7 +92,7 @@ public class RealValuedInitializerTests {
             new double[] {2 + Math.ulp(2), 2 + Math.ulp(2)},
             new double[] {0, 0},
             new double[] {2, 2});
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
   }
 
   @Test
@@ -241,9 +213,18 @@ public class RealValuedInitializerTests {
     int n = 1;
     RealVectorInitializer f = new RealVectorInitializer(n, a, b);
     RealVectorInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       RealVector g = f.createCandidateSolution();
+      assertTrue(g.get(0) < b && g.get(0) >= a);
+      assertEquals(theClass.getClass(), g.getClass());
+      assertEquals(n, g.length());
+      RealVector copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      RealVector g = fs.createCandidateSolution();
       assertTrue(g.get(0) < b && g.get(0) >= a);
       assertEquals(theClass.getClass(), g.getClass());
       assertEquals(n, g.length());
@@ -401,9 +382,23 @@ public class RealValuedInitializerTests {
     double max = 20;
     RealVectorInitializer f = new RealVectorInitializer(n, a, b, min, max);
     RealVectorInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       RealVector g = f.createCandidateSolution();
+      assertEquals(n, g.length());
+      assertTrue(g.get(0) < b && g.get(0) >= a);
+      g.set(0, min - 1);
+      assertEquals(min, g.get(0), EPSILON);
+      g.set(0, max + 1);
+      assertEquals(max, g.get(0), EPSILON);
+      g.set(0, 10);
+      assertEquals(10, g.get(0), EPSILON);
+      RealVector copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      RealVector g = fs.createCandidateSolution();
       assertEquals(n, g.length());
       assertTrue(g.get(0) < b && g.get(0) >= a);
       g.set(0, min - 1);

--- a/src/test/java/org/cicirello/search/operators/reals/RealValuedInitializerTests.java
+++ b/src/test/java/org/cicirello/search/operators/reals/RealValuedInitializerTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2023 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -36,24 +36,6 @@ public class RealValuedInitializerTests {
   private final double EPSILON = 1e-10;
 
   @Test
-  public void testRealValueInitializerEquals() {
-    RealValueInitializer f = new RealValueInitializer(2, 3, 0, 5);
-    RealValueInitializer g = new RealValueInitializer(2, 3, 0, 5);
-    RealValueInitializer f1 = new RealValueInitializer(1, 3, 0, 5);
-    RealValueInitializer f2 = new RealValueInitializer(2, 4, 0, 5);
-    RealValueInitializer f3 = new RealValueInitializer(2, 3, -1, 5);
-    RealValueInitializer f4 = new RealValueInitializer(2, 3, 0, 6);
-    assertEquals(f, g);
-    assertEquals(f.hashCode(), g.hashCode());
-    assertNotEquals(f, f1);
-    assertNotEquals(f, f2);
-    assertNotEquals(f, f3);
-    assertNotEquals(f, f4);
-    assertNotEquals(f, null);
-    assertNotEquals(f, "hello");
-  }
-
-  @Test
   public void testRealVectorInitializerEquals() {
     RealVectorInitializer f = new RealVectorInitializer(2, 2, 4, 0, 8);
     RealVectorInitializer g = new RealVectorInitializer(2, 2, 4, 0, 8);
@@ -87,7 +69,7 @@ public class RealValuedInitializerTests {
     SingleReal g1 = f.createCandidateSolution();
     SingleReal g2 = f.createCandidateSolution();
     SingleReal h = new SingleReal(2);
-    assertFalse(g1.equals(h));
+    assertTrue(g1.equals(h));
     assertFalse(g1.equals(null));
     assertFalse(g1.equals("hello"));
     assertEquals(g1, g2);
@@ -99,7 +81,7 @@ public class RealValuedInitializerTests {
     f2 = new RealValueInitializer(2, 2 + Math.ulp(2), 2, 3);
     assertNotEquals(g1, f2.createCandidateSolution());
     f2 = new RealValueInitializer(2, 2 + Math.ulp(2), 0, 2);
-    assertNotEquals(g1, f2.createCandidateSolution());
+    assertEquals(g1, f2.createCandidateSolution());
   }
 
   @Test
@@ -148,9 +130,21 @@ public class RealValuedInitializerTests {
     double b = 11.0;
     RealValueInitializer f = new RealValueInitializer(a, b);
     RealValueInitializer fs = f.split();
-    assertEquals(f, fs);
     for (int i = 0; i < NUM_SAMPLES; i++) {
       SingleReal g = f.createCandidateSolution();
+      assertTrue(g.get(0) < b && g.get(0) >= a);
+      assertEquals(theClass.getClass(), g.getClass());
+      SingleReal copy = g.copy();
+      assertTrue(copy != g);
+      assertEquals(g, copy);
+      assertEquals(g.getClass(), copy.getClass());
+      g.set(0, a - 1);
+      assertEquals(a - 1, g.get(0), EPSILON);
+      g.set(0, b + 1);
+      assertEquals(b + 1, g.get(0), EPSILON);
+    }
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+      SingleReal g = fs.createCandidateSolution();
       assertTrue(g.get(0) < b && g.get(0) >= a);
       assertEquals(theClass.getClass(), g.getClass());
       SingleReal copy = g.copy();

--- a/src/test/java/org/cicirello/search/problems/BoundMaxTests.java
+++ b/src/test/java/org/cicirello/search/problems/BoundMaxTests.java
@@ -29,19 +29,6 @@ import org.junit.jupiter.api.*;
 public class BoundMaxTests {
 
   @Test
-  public void testEquals() {
-    BoundMax b1 = new BoundMax(10, 3);
-    BoundMax b2 = new BoundMax(10, 3);
-    BoundMax b3 = new BoundMax(11, 3);
-    BoundMax b4 = new BoundMax(10, 4);
-    assertEquals(b1, b2);
-    assertNotEquals(b1, b3);
-    assertNotEquals(b1, b4);
-    assertFalse(b1.equals(null));
-    assertFalse(b1.equals("hello"));
-  }
-
-  @Test
   public void testInitializerMethods() {
     for (int n = 0; n < 5; n++) {
       for (int bound = 0; bound < 5; bound++) {


### PR DESCRIPTION
## Summary
Removed unnecessary equals() and hashCode() methods from evolutionary operators. These were nonsensical. You should never need to compare these for equality, etc. 

## Closing Issues
Closes #668 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
