### PR TITLE
Fixed TimedParallelMultistarter.getSearchHistory()  to return a copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved BlockInterchangeIterator.rollback().
 * Performance improvement to LargestCommonSubgraph.
 * Removed unnecessary equals() and hashCode() methods from evolutionary operators.
+* Return a copy from TimedParallelMultistarter.getSearchHistory() rather than reference to field.
 
 ### Dependencies
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -4,11 +4,4 @@
     <Bug code="SECPTI,SECPTO" />
 	<Package name="org.cicirello.search.problems.scheduling" />
   </Match>
-  
-  <!-- False positive exposed representation -->
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP" />
-	<Class name="org.cicirello.search.concurrent.TimedParallelMultistarter" />
-	<Method name="getSearchHistory" />
-  </Match>
 </FindBugsFilter>

--- a/src/main/java/org/cicirello/search/concurrent/TimedParallelMultistarter.java
+++ b/src/main/java/org/cicirello/search/concurrent/TimedParallelMultistarter.java
@@ -294,7 +294,7 @@ public class TimedParallelMultistarter<T extends Copyable<T>>
    *     #optimize} has not been called.
    */
   public final ArrayList<SolutionCostPair<T>> getSearchHistory() {
-    return history;
+    return history == null ? null : new ArrayList<SolutionCostPair<T>>(history);
   }
 
   /**


### PR DESCRIPTION
## Summary
Return a copy from TimedParallelMultistarter.getSearchHistory() rather than reference to field.

## Closing Issues
Closes #670 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
