### PR TITLE
Refactored all the constructive scheduling heuristics and single machine scheduling problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-07-08
+## [Unreleased] - 2026-07-10
+
+__BREAKING CHANGES: Next release will be 8.0.0.__
 
 ### Added
 
-### Changed
+### Changed (BREAKING)
+* Refactored all the constructive scheduling heuristics and single machine scheduling problems:
+  * To remove the getInstanceData() method from the SingleMachineSchedulingProblem interface, and
+  * To require passing an instance of SingleMachineSchedulingProblemData, in addition to the SingleMachineSchedulingProblem, to the constructive scheduling heuristics.
 
 ### Deprecated
 

--- a/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
@@ -50,6 +50,7 @@ public final class ATCS extends WeightedShortestProcessingTime {
   private final double pAve;
   private final double sAve;
   private final boolean ADJUST_FOR_SETUPS;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an ATCS heuristic.
@@ -62,6 +63,7 @@ public final class ATCS extends WeightedShortestProcessingTime {
    */
   public ATCS(SingleMachineSchedulingProblem problem, double k1, double k2) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -69,8 +71,8 @@ public final class ATCS extends WeightedShortestProcessingTime {
       throw new IllegalArgumentException("k1 and k2 must be positive");
     }
     int n = data.numberOfJobs();
-    pAve = ((double) sumOfProcessingTimes()) / n;
-    int totalSetupTimes = sumOfSetupTimes();
+    pAve = ((double) data.sumOfProcessingTimes()) / n;
+    int totalSetupTimes = data.sumOfSetupTimes();
     if (totalSetupTimes == 0) {
       sAve = 0.0;
       ADJUST_FOR_SETUPS = false;
@@ -91,6 +93,7 @@ public final class ATCS extends WeightedShortestProcessingTime {
    */
   public ATCS(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -98,10 +101,10 @@ public final class ATCS extends WeightedShortestProcessingTime {
     int n = data.numberOfJobs();
     double cv = 0;
     double eta = 0;
-    int pSum = sumOfProcessingTimes();
+    int pSum = data.sumOfProcessingTimes();
     double cmax = pSum;
     pAve = ((double) pSum) / n;
-    int totalSetupTimes = sumOfSetupTimes();
+    int totalSetupTimes = data.sumOfSetupTimes();
     if (totalSetupTimes == 0) {
       sAve = 0.0;
       ADJUST_FOR_SETUPS = false;

--- a/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
@@ -55,15 +55,20 @@ public final class ATCS extends WeightedShortestProcessingTime {
   /**
    * Constructs an ATCS heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k1 A parameter to the heuristic, which must be positive.
    * @param k2 A parameter to the heuristic, which must be positive.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public ATCS(SingleMachineSchedulingProblem problem, double k1, double k2) {
-    super(problem);
-    data = problem.getInstanceData();
+  public ATCS(
+      SingleMachineSchedulingProblem problem,
+      SingleMachineSchedulingProblemData data,
+      double k1,
+      double k2) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -88,12 +93,13 @@ public final class ATCS extends WeightedShortestProcessingTime {
    * Constructs an ATCS heuristic. Sets the values of k1 and k2 according to the procedure described
    * by the authors of the ATCS heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public ATCS(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public ATCS(SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ATCS.java
@@ -128,7 +128,7 @@ public final class ATCS extends WeightedShortestProcessingTime {
       final double BETA = cv == 0 ? 1.0 : 1.0 - (1.0 - BETA_MIN) * cv / 0.3333333333;
       cmax += n * sAve * BETA;
     }
-    double[] d_stats = computeDueDateStats();
+    double[] d_stats = data.dueDateStats();
     double R = (d_stats[1] - d_stats[0]) / cmax;
     double tau = 1.0 - d_stats[2] / cmax;
     if (R <= 0.5) k1 = 4.5 + R;
@@ -188,20 +188,6 @@ public final class ATCS extends WeightedShortestProcessingTime {
     return new IncrementalTimeCalculator();
   }
 
-  private double[] computeDueDateStats() {
-    int min = data.getDueDate(0);
-    int max = min;
-    int sum = min;
-    int n = data.numberOfJobs();
-    for (int i = 1; i < n; i++) {
-      int d = data.getDueDate(i);
-      if (d < min) min = d;
-      else if (d > max) max = d;
-      sum += d;
-    }
-    return new double[] {min, max, ((double) sum) / n};
-  }
-
   private double setupVariance(double mean) {
     int n = data.numberOfJobs();
     double total = 0;
@@ -212,10 +198,5 @@ public final class ATCS extends WeightedShortestProcessingTime {
       }
     }
     return total / (n * n) - mean * mean;
-  }
-
-  /* package-private: here to support testing only */
-  final double getSetupAverage() {
-    return sAve;
   }
 }

--- a/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCost.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCost.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -40,7 +40,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2021
  */
 public final class ApparentTardinessCost extends WeightedShortestProcessingTime {
 
@@ -58,12 +57,13 @@ public final class ApparentTardinessCost extends WeightedShortestProcessingTime 
    */
   public ApparentTardinessCost(SingleMachineSchedulingProblem problem, double k) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
     if (k <= 0.0) throw new IllegalArgumentException("k must be positive");
     this.k = k;
-    totalProcessTime = sumOfProcessingTimes();
+    totalProcessTime = data.sumOfProcessingTimes();
   }
 
   /**

--- a/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCost.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCost.java
@@ -49,15 +49,16 @@ public final class ApparentTardinessCost extends WeightedShortestProcessingTime 
   /**
    * Constructs an ApparentTardinessCost heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k A parameter to the heuristic, which must be positive. Typical good values are in the
    *     interval [1.0, 4.0] but it is not limited to that interval.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public ApparentTardinessCost(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public ApparentTardinessCost(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -69,11 +70,13 @@ public final class ApparentTardinessCost extends WeightedShortestProcessingTime 
   /**
    * Constructs an ApparentTardinessCost heuristic. Uses a default of k=2.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public ApparentTardinessCost(SingleMachineSchedulingProblem problem) {
-    this(problem, 2.0);
+  public ApparentTardinessCost(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 2.0);
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjusted.java
@@ -57,15 +57,16 @@ public final class ApparentTardinessCostSetupAdjusted
   /**
    * Constructs an ApparentTardinessCostSetupAdjusted heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k A parameter to the heuristic, which must be positive. Typical good values are in the
    *     interval [1.0, 4.0] but it is not limited to that interval.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public ApparentTardinessCostSetupAdjusted(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public ApparentTardinessCostSetupAdjusted(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -77,11 +78,13 @@ public final class ApparentTardinessCostSetupAdjusted
   /**
    * Constructs an ApparentTardinessCostSetupAdjusted heuristic. Uses a default of k=2.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public ApparentTardinessCostSetupAdjusted(SingleMachineSchedulingProblem problem) {
-    this(problem, 2.0);
+  public ApparentTardinessCostSetupAdjusted(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 2.0);
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjusted.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -47,7 +47,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2021
  */
 public final class ApparentTardinessCostSetupAdjusted
     extends WeightedShortestProcessingPlusSetupTime {
@@ -66,12 +65,13 @@ public final class ApparentTardinessCostSetupAdjusted
    */
   public ApparentTardinessCostSetupAdjusted(SingleMachineSchedulingProblem problem, double k) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
     if (k <= 0.0) throw new IllegalArgumentException("k must be positive");
     this.k = k;
-    totalProcessTime = sumOfProcessingTimes();
+    totalProcessTime = data.sumOfProcessingTimes();
   }
 
   /**

--- a/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
@@ -58,15 +58,20 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
   /**
    * Constructs an DynamicATCS heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k1 A parameter to the heuristic, which must be positive.
    * @param k2 A parameter to the heuristic, which must be positive.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public DynamicATCS(SingleMachineSchedulingProblem problem, double k1, double k2) {
-    super(problem);
-    data = problem.getInstanceData();
+  public DynamicATCS(
+      SingleMachineSchedulingProblem problem,
+      SingleMachineSchedulingProblemData data,
+      double k1,
+      double k2) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -84,12 +89,14 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
    * Constructs an DynamicATCS heuristic. Sets the values of k1 and k2 according to the procedure
    * described by the authors of the ATCS heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public DynamicATCS(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public DynamicATCS(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
@@ -53,6 +53,7 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
   private final int pSum;
   private final int sSum;
   private final boolean ADJUST_FOR_SETUPS;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an DynamicATCS heuristic.
@@ -65,14 +66,15 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
    */
   public DynamicATCS(SingleMachineSchedulingProblem problem, double k1, double k2) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
     if (k1 <= 0.0 || k2 <= 0.0) {
       throw new IllegalArgumentException("k1 and k2 must be positive");
     }
-    pSum = sumOfProcessingTimes();
-    sSum = sumOfSetupTimes();
+    pSum = data.sumOfProcessingTimes();
+    sSum = data.sumOfSetupTimes();
     ADJUST_FOR_SETUPS = sSum != 0;
     this.k1 = k1;
     this.k2 = k2;
@@ -87,13 +89,14 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
    */
   public DynamicATCS(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
 
     int n = data.numberOfJobs();
-    pSum = sumOfProcessingTimes();
-    sSum = sumOfSetupTimes();
+    pSum = data.sumOfProcessingTimes();
+    sSum = data.sumOfSetupTimes();
     double cv = 0;
     double eta = 0;
     double cmax = pSum;

--- a/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/DynamicATCS.java
@@ -121,7 +121,7 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
     } else {
       ADJUST_FOR_SETUPS = false;
     }
-    double[] d_stats = computeDueDateStats();
+    double[] d_stats = data.dueDateStats();
     double R = (d_stats[1] - d_stats[0]) / cmax;
     double tau = 1.0 - d_stats[2] / cmax;
     if (R <= 0.5) k1 = 4.5 + R;
@@ -185,20 +185,6 @@ public final class DynamicATCS extends WeightedShortestProcessingTime {
   @Override
   public IncrementalEvaluation<Permutation> createIncrementalEvaluation() {
     return new IncrementalStatsCalculator(pSum, sSum);
-  }
-
-  private double[] computeDueDateStats() {
-    int min = data.getDueDate(0);
-    int max = min;
-    int sum = min;
-    int n = data.numberOfJobs();
-    for (int i = 1; i < n; i++) {
-      int d = data.getDueDate(i);
-      if (d < min) min = d;
-      else if (d > max) max = d;
-      sum += d;
-    }
-    return new double[] {min, max, ((double) sum) / n};
   }
 
   private double setupVariance(double mean) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/EarliestDueDate.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/EarliestDueDate.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -36,7 +36,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class EarliestDueDate extends SchedulingHeuristic {
 
@@ -50,6 +49,7 @@ public final class EarliestDueDate extends SchedulingHeuristic {
    */
   public EarliestDueDate(SingleMachineSchedulingProblem problem) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/EarliestDueDate.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/EarliestDueDate.java
@@ -44,12 +44,13 @@ public final class EarliestDueDate extends SchedulingHeuristic {
   /**
    * Constructs an EarliestDueDate heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public EarliestDueDate(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public EarliestDueDate(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -56,7 +56,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.31.2020
  */
 public final class ExponentialEarlyTardyHeuristic extends SchedulingHeuristic {
 
@@ -86,6 +85,7 @@ public final class ExponentialEarlyTardyHeuristic extends SchedulingHeuristic {
     super(problem);
     if (k < 1) throw new IllegalArgumentException("k must be at least 1");
     // pre-compute WLPT and WSPT, and cache results.
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     wlpt = new double[data.numberOfJobs()];
     wspt = new double[data.numberOfJobs()];
     double minimum = 0;
@@ -97,7 +97,7 @@ public final class ExponentialEarlyTardyHeuristic extends SchedulingHeuristic {
     // shift heuristic values by minimum to ensure all positive values.
     shift = MIN_H - minimum;
     this.k = k;
-    totalProcessTime = sumOfProcessingTimes();
+    totalProcessTime = data.sumOfProcessingTimes();
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristic.java
@@ -68,24 +68,27 @@ public final class ExponentialEarlyTardyHeuristic extends SchedulingHeuristic {
   /**
    * Constructs a ExponentialEarlyTardyHeuristic heuristic. Uses a default value of k=1.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public ExponentialEarlyTardyHeuristic(SingleMachineSchedulingProblem problem) {
-    this(problem, 1.0);
+  public ExponentialEarlyTardyHeuristic(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 1.0);
   }
 
   /**
    * Constructs a ExponentialEarlyTardyHeuristic heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k A parameter of the heuristic (see class documentation). Must be at least 1.
    * @throws IllegalArgumentException if k &lt; 1.
    */
-  public ExponentialEarlyTardyHeuristic(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
+  public ExponentialEarlyTardyHeuristic(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
     if (k < 1) throw new IllegalArgumentException("k must be at least 1");
     // pre-compute WLPT and WSPT, and cache results.
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     wlpt = new double[data.numberOfJobs()];
     wspt = new double[data.numberOfJobs()];
     double minimum = 0;

--- a/src/main/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristic.java
@@ -65,26 +65,29 @@ public final class LinearEarlyTardyHeuristic extends SchedulingHeuristic {
   /**
    * Constructs a LinearEarlyTardyHeuristic heuristic. Uses a default value of k=1.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public LinearEarlyTardyHeuristic(SingleMachineSchedulingProblem problem) {
-    this(problem, 1.0);
+  public LinearEarlyTardyHeuristic(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 1.0);
   }
 
   /**
    * Constructs a LinearEarlyTardyHeuristic heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k A parameter of the heuristic (see class documentation). Must be at least 1.
    * @throws IllegalArgumentException if k &lt; 1.
    */
-  public LinearEarlyTardyHeuristic(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
+  public LinearEarlyTardyHeuristic(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
     if (k < 1) {
       throw new IllegalArgumentException("k must be at least 1");
     }
     // pre-compute WLPT and WSPT, and cache results.
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     wlpt = new double[data.numberOfJobs()];
     wspt = new double[data.numberOfJobs()];
     double minimum = 0;

--- a/src/main/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -54,7 +54,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.12.2020
  */
 public final class LinearEarlyTardyHeuristic extends SchedulingHeuristic {
 
@@ -81,8 +80,11 @@ public final class LinearEarlyTardyHeuristic extends SchedulingHeuristic {
    */
   public LinearEarlyTardyHeuristic(SingleMachineSchedulingProblem problem, double k) {
     super(problem);
-    if (k < 1) throw new IllegalArgumentException("k must be at least 1");
+    if (k < 1) {
+      throw new IllegalArgumentException("k must be at least 1");
+    }
     // pre-compute WLPT and WSPT, and cache results.
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     wlpt = new double[data.numberOfJobs()];
     wspt = new double[data.numberOfJobs()];
     double minimum = 0;
@@ -98,7 +100,7 @@ public final class LinearEarlyTardyHeuristic extends SchedulingHeuristic {
       wspt[i] += shift;
     }
     this.k = k;
-    totalProcessTime = sumOfProcessingTimes();
+    totalProcessTime = data.sumOfProcessingTimes();
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMakespan.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMakespan.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,7 +32,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class MinimizeMakespan implements SingleMachineSchedulingProblem {
 
@@ -51,11 +50,6 @@ public final class MinimizeMakespan implements SingleMachineSchedulingProblem {
     for (int i = 0; i < n; i++) {
       lowerBound += instanceData.getProcessingTime(i);
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumFlowtime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumFlowtime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -30,7 +30,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class MinimizeMaximumFlowtime implements SingleMachineSchedulingProblem {
 
@@ -43,11 +42,6 @@ public final class MinimizeMaximumFlowtime implements SingleMachineSchedulingPro
    */
   public MinimizeMaximumFlowtime(SingleMachineSchedulingProblemData instanceData) {
     this.instanceData = instanceData;
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumLateness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumLateness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class MinimizeMaximumLateness implements SingleMachineSchedulingProblem {
 
@@ -48,11 +47,6 @@ public final class MinimizeMaximumLateness implements SingleMachineSchedulingPro
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumTardiness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimizeMaximumTardiness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class MinimizeMaximumTardiness implements SingleMachineSchedulingProblem {
 
@@ -48,11 +47,6 @@ public final class MinimizeMaximumTardiness implements SingleMachineSchedulingPr
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimumSlackTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimumSlackTime.java
@@ -55,12 +55,14 @@ public final class MinimumSlackTime extends SchedulingHeuristic {
   /**
    * Constructs an MinimumSlackTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public MinimumSlackTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public MinimumSlackTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/MinimumSlackTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/MinimumSlackTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -45,12 +45,12 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class MinimumSlackTime extends SchedulingHeuristic {
 
   private final int DMAX;
   private final double[] h;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an MinimumSlackTime heuristic.
@@ -60,6 +60,7 @@ public final class MinimumSlackTime extends SchedulingHeuristic {
    */
   public MinimumSlackTime(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -73,7 +74,7 @@ public final class MinimumSlackTime extends SchedulingHeuristic {
 
   @Override
   public double h(Partial<Permutation> p, int element, IncrementalEvaluation<Permutation> incEval) {
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       return h[element]
           + (p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element));
     } else {

--- a/src/main/java/org/cicirello/search/problems/scheduling/Montagne.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/Montagne.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -37,11 +37,11 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class Montagne extends WeightedShortestProcessingTime {
 
   private final int totalProcessTime;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an Montagne heuristic.
@@ -51,10 +51,11 @@ public final class Montagne extends WeightedShortestProcessingTime {
    */
   public Montagne(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
-    totalProcessTime = sumOfProcessingTimes();
+    totalProcessTime = problem.getInstanceData().sumOfProcessingTimes();
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/Montagne.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/Montagne.java
@@ -46,16 +46,17 @@ public final class Montagne extends WeightedShortestProcessingTime {
   /**
    * Constructs an Montagne heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public Montagne(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public Montagne(SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
-    totalProcessTime = problem.getInstanceData().sumOfProcessingTimes();
+    totalProcessTime = data.sumOfProcessingTimes();
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/SchedulingHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SchedulingHeuristic.java
@@ -53,11 +53,13 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
   /**
    * Initializes the abstract base class for scheduling heuristics.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public SchedulingHeuristic(SingleMachineSchedulingProblem problem) {
+  public SchedulingHeuristic(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
     this.problem = problem;
-    data = problem.getInstanceData();
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/SchedulingHeuristic.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SchedulingHeuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -45,12 +45,10 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
   public static final double MIN_H = 0.00001;
 
   /** The instance of the scheduling problem that is the target of the heuristic. */
-  final SingleMachineSchedulingProblem problem;
+  private final SingleMachineSchedulingProblem problem;
 
   /** The instance data of the scheduling problem that is the target of the heuristic. */
-  final SingleMachineSchedulingProblemData data;
-
-  final boolean HAS_SETUPS;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Initializes the abstract base class for scheduling heuristics.
@@ -60,7 +58,6 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
   public SchedulingHeuristic(SingleMachineSchedulingProblem problem) {
     this.problem = problem;
     data = problem.getInstanceData();
-    HAS_SETUPS = data.hasSetupTimes();
   }
 
   @Override
@@ -81,33 +78,6 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
   /*
    * package-private rather than private to enable test case access
    */
-  int sumOfProcessingTimes() {
-    int total = 0;
-    int n = data.numberOfJobs();
-    for (int i = 0; i < n; i++) {
-      total += data.getProcessingTime(i);
-    }
-    return total;
-  }
-
-  /*
-   * package-private rather than private to enable test case access
-   */
-  int sumOfSetupTimes() {
-    if (!HAS_SETUPS) return 0;
-    int total = 0;
-    int n = data.numberOfJobs();
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < n; j++) {
-        total += data.getSetupTime(i, j);
-      }
-    }
-    return total;
-  }
-
-  /*
-   * package-private rather than private to enable test case access
-   */
   class IncrementalTimeCalculator implements IncrementalEvaluation<Permutation> {
 
     private int currentTime;
@@ -115,7 +85,7 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
     @Override
     public void extend(Partial<Permutation> p, int element) {
       currentTime += data.getProcessingTime(element);
-      if (HAS_SETUPS) {
+      if (data.hasSetupTimes()) {
         currentTime +=
             p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element);
       }
@@ -149,7 +119,7 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
      */
     public final int slack(int element, Partial<Permutation> p) {
       int s = slack(element);
-      if (HAS_SETUPS) {
+      if (data.hasSetupTimes()) {
         s -= p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element);
       }
       return s;
@@ -175,7 +145,7 @@ abstract class SchedulingHeuristic implements ConstructiveHeuristic<Permutation>
      */
     public final int slackPlus(int element, Partial<Permutation> p) {
       int s = slack(element);
-      if (HAS_SETUPS && s > 0) {
+      if (data.hasSetupTimes() && s > 0) {
         s -= p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element);
       }
       return s > 0 ? s : 0;

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTime.java
@@ -50,11 +50,13 @@ public final class ShortestProcessingPlusSetupTime extends SchedulingHeuristic {
   /**
    * Constructs an ShortestProcessingPlusSetupTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public ShortestProcessingPlusSetupTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public ShortestProcessingPlusSetupTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -42,9 +42,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 2.22.2021
  */
 public final class ShortestProcessingPlusSetupTime extends SchedulingHeuristic {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an ShortestProcessingPlusSetupTime heuristic.
@@ -53,12 +54,13 @@ public final class ShortestProcessingPlusSetupTime extends SchedulingHeuristic {
    */
   public ShortestProcessingPlusSetupTime(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
   }
 
   @Override
   public double h(Partial<Permutation> p, int element, IncrementalEvaluation<Permutation> incEval) {
     double denominator = data.getProcessingTime(element);
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       denominator +=
           (p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element));
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecompute.java
@@ -50,11 +50,12 @@ public final class ShortestProcessingPlusSetupTimePrecompute extends SchedulingH
   /**
    * Constructs an ShortestProcessingPlusSetupTimePrecompute heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public ShortestProcessingPlusSetupTimePrecompute(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public ShortestProcessingPlusSetupTimePrecompute(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     final int n = data.numberOfJobs();
     h = new double[n][n];
     if (data.hasSetupTimes()) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecompute.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -42,7 +42,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2021
  */
 public final class ShortestProcessingPlusSetupTimePrecompute extends SchedulingHeuristic {
 
@@ -55,9 +54,10 @@ public final class ShortestProcessingPlusSetupTimePrecompute extends SchedulingH
    */
   public ShortestProcessingPlusSetupTimePrecompute(SingleMachineSchedulingProblem problem) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     final int n = data.numberOfJobs();
     h = new double[n][n];
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       for (int i = 0; i < n; i++) {
         h[i][i] = Math.max(MIN_H, 1.0 / (data.getProcessingTime(i) + data.getSetupTime(i)));
         for (int j = i + 1; j < n; j++) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingTime.java
@@ -42,12 +42,13 @@ public final class ShortestProcessingTime extends SchedulingHeuristic {
   /**
    * Constructs an ShortestProcessingTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public ShortestProcessingTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
+  public ShortestProcessingTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     // pre-compute h and cache results.
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     h = new double[data.numberOfJobs()];
     for (int i = 0; i < h.length; i++) {
       h[i] = 1.0 / data.getProcessingTime(i);

--- a/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/ShortestProcessingTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -34,7 +34,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 2.22.2021
  */
 public final class ShortestProcessingTime extends SchedulingHeuristic {
 
@@ -48,6 +47,7 @@ public final class ShortestProcessingTime extends SchedulingHeuristic {
   public ShortestProcessingTime(SingleMachineSchedulingProblem problem) {
     super(problem);
     // pre-compute h and cache results.
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     h = new double[data.numberOfJobs()];
     for (int i = 0; i < h.length; i++) {
       h[i] = 1.0 / data.getProcessingTime(i);

--- a/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblem.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblem.java
@@ -26,23 +26,13 @@ import org.cicirello.search.problems.IntegerCostOptimizationProblem;
 /**
  * Implement this interface to define a single machine scheduling problem. A class that implements
  * this interface should implement the cost function for the problem (i.e., the function we are
- * optimizing) and must utilize a class implementing the {@link SingleMachineSchedulingProblemData}
- * interface to represent the data describing the instance, such as processing times, due dates,
- * etc. You may have a single class that implements both interfaces, if desired, in which case, the
- * {@link #getInstanceData} could just return the this reference.
+ * optimizing) and should utilize a class implementing the {@link
+ * SingleMachineSchedulingProblemData} interface to represent the data describing the instance, such
+ * as processing times, due dates, etc. You may have a single class that implements both interfaces,
+ * if desired.
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public interface SingleMachineSchedulingProblem
-    extends IntegerCostOptimizationProblem<Permutation> {
-
-  /**
-   * Gets an object that encapsulates the data describing the scheduling problem instance, such as
-   * number of jobs, and the characteristics of the jobs, such as processing times, setup times, due
-   * dates, weights, etc.
-   *
-   * @return an encapsulation of the data describing the scheduling problem instance
-   */
-  SingleMachineSchedulingProblemData getInstanceData();
-}
+    extends IntegerCostOptimizationProblem<Permutation> {}

--- a/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblem.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblem.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -33,7 +33,6 @@ import org.cicirello.search.problems.IntegerCostOptimizationProblem;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public interface SingleMachineSchedulingProblem
     extends IntegerCostOptimizationProblem<Permutation> {

--- a/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.java
@@ -121,6 +121,27 @@ public interface SingleMachineSchedulingProblemData {
   }
 
   /**
+   * Computes the minimum, maximum, and average duedate.
+   *
+   * @return an array of duedate statistics of the form [min, max, average]
+   * @throws UnsupportedOperationException if {@link #hasDueDates} returns false. This is the
+   *     behavior if the scheduling problem definition doesn't have due dates.
+   */
+  default double[] dueDateStats() {
+    int min = getDueDate(0);
+    int max = min;
+    int sum = min;
+    final int n = numberOfJobs();
+    for (int i = 1; i < n; i++) {
+      int d = getDueDate(i);
+      if (d < min) min = d;
+      else if (d > max) max = d;
+      sum += d;
+    }
+    return new double[] {min, max, ((double) sum) / n};
+  }
+
+  /**
    * Gets the release date of a job, for scheduling problems that have release dates. The default
    * implementation simply returns 0, which is appropriate for problems without release dates (i.e.,
    * problems in which all jobs are available for scheduling right at the start). You can use the

--- a/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SingleMachineSchedulingProblemData.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -47,7 +47,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.13.2020
  */
 public interface SingleMachineSchedulingProblemData {
 
@@ -82,6 +81,20 @@ public interface SingleMachineSchedulingProblemData {
    * @throws IllegalArgumentException if schedule.length() is not equal to numberOfJobs()
    */
   int[] getCompletionTimes(Permutation schedule);
+
+  /**
+   * Computes the sum of the processing times of all of the jobs.
+   *
+   * @return the sum of the processing times of the jobs
+   */
+  default int sumOfProcessingTimes() {
+    int total = 0;
+    final int n = numberOfJobs();
+    for (int i = 0; i < n; i++) {
+      total += getProcessingTime(i);
+    }
+    return total;
+  }
 
   /**
    * Gets the due date of a job, for scheduling problems that have due dates. The meaning of a due
@@ -200,7 +213,6 @@ public interface SingleMachineSchedulingProblemData {
   default int getSetupTime(int i, int j) {
     return 0;
   }
-  ;
 
   /**
    * Gets the setup time of a job if it is the first job processed on the machine. The default
@@ -216,7 +228,6 @@ public interface SingleMachineSchedulingProblemData {
   default int getSetupTime(int j) {
     return 0;
   }
-  ;
 
   /**
    * Checks whether this single machine scheduling instance has setup times.
@@ -225,5 +236,24 @@ public interface SingleMachineSchedulingProblemData {
    */
   default boolean hasSetupTimes() {
     return false;
+  }
+
+  /**
+   * Computes the sum of setup times of the jobs for problems with setup times.
+   *
+   * @return the sum of the setup times, or 0 if the problem doesn't have setup times.
+   */
+  default int sumOfSetupTimes() {
+    if (!hasSetupTimes()) {
+      return 0;
+    }
+    int total = 0;
+    final int n = numberOfJobs();
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < n; j++) {
+        total += getSetupTime(i, j);
+      }
+    }
+    return total;
   }
 }

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetup.java
@@ -41,11 +41,13 @@ public final class SmallestNormalizedSetup extends SchedulingHeuristic {
   /**
    * Constructs an SmallestNormalizedSetup heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public SmallestNormalizedSetup(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public SmallestNormalizedSetup(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetup.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -33,9 +33,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class SmallestNormalizedSetup extends SchedulingHeuristic {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an SmallestNormalizedSetup heuristic.
@@ -44,11 +45,12 @@ public final class SmallestNormalizedSetup extends SchedulingHeuristic {
    */
   public SmallestNormalizedSetup(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
   }
 
   @Override
   public double h(Partial<Permutation> p, int element, IncrementalEvaluation<Permutation> incEval) {
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       int n = p.numExtensions();
       if (n == 1) return 0.5;
       double s =
@@ -68,8 +70,7 @@ public final class SmallestNormalizedSetup extends SchedulingHeuristic {
       // jobs n to be at least 1/MIN_H, al but one of which to have setup of 0.
       // Check here probably unnecessary.
       return h <= MIN_H ? MIN_H : h;
-    } else {
-      return 1;
     }
+    return 1;
   }
 }

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetup.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -36,9 +36,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 2.16.2021
  */
 public final class SmallestSetup extends SchedulingHeuristic {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an SmallestSetup heuristic.
@@ -47,11 +48,12 @@ public final class SmallestSetup extends SchedulingHeuristic {
    */
   public SmallestSetup(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
   }
 
   @Override
   public double h(Partial<Permutation> p, int element, IncrementalEvaluation<Permutation> incEval) {
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       double s =
           1.0
               / (1.0
@@ -59,8 +61,7 @@ public final class SmallestSetup extends SchedulingHeuristic {
                       ? data.getSetupTime(element)
                       : data.getSetupTime(p.getLast(), element)));
       return s <= MIN_H ? MIN_H : s;
-    } else {
-      return 1;
     }
+    return 1;
   }
 }

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetup.java
@@ -44,11 +44,13 @@ public final class SmallestSetup extends SchedulingHeuristic {
   /**
    * Constructs an SmallestSetup heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public SmallestSetup(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public SmallestSetup(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecompute.java
@@ -46,11 +46,12 @@ public final class SmallestSetupPrecompute extends SchedulingHeuristic {
   /**
    * Constructs an SmallestSetupPrecompute heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public SmallestSetupPrecompute(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public SmallestSetupPrecompute(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     int n = data.numberOfJobs();
     h = new double[n][n];
     if (data.hasSetupTimes()) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecompute.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -38,7 +38,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 2.22.2021
  */
 public final class SmallestSetupPrecompute extends SchedulingHeuristic {
 
@@ -51,9 +50,10 @@ public final class SmallestSetupPrecompute extends SchedulingHeuristic {
    */
   public SmallestSetupPrecompute(SingleMachineSchedulingProblem problem) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     int n = data.numberOfJobs();
     h = new double[n][n];
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       for (int i = 0; i < n; i++) {
         h[i][i] = Math.max(MIN_H, 1.0 / (1.0 + data.getSetupTime(i)));
         for (int j = i + 1; j < n; j++) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetup.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,9 +32,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class SmallestTwoJobSetup extends SchedulingHeuristic {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an SmallestTwoJobSetup heuristic.
@@ -43,11 +44,12 @@ public final class SmallestTwoJobSetup extends SchedulingHeuristic {
    */
   public SmallestTwoJobSetup(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
   }
 
   @Override
   public double h(Partial<Permutation> p, int element, IncrementalEvaluation<Permutation> incEval) {
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       double denominator =
           1.0
               + (p.size() == 0

--- a/src/main/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetup.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetup.java
@@ -40,11 +40,13 @@ public final class SmallestTwoJobSetup extends SchedulingHeuristic {
   /**
    * Constructs an SmallestTwoJobSetup heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public SmallestTwoJobSetup(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public SmallestTwoJobSetup(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -39,11 +39,11 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedCostOverTime extends WeightedShortestProcessingTime {
 
   private final double k;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an WeightedCostOverTime heuristic.
@@ -56,6 +56,7 @@ public final class WeightedCostOverTime extends WeightedShortestProcessingTime {
    */
   public WeightedCostOverTime(SingleMachineSchedulingProblem problem, double k) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTime.java
@@ -48,15 +48,17 @@ public final class WeightedCostOverTime extends WeightedShortestProcessingTime {
   /**
    * Constructs an WeightedCostOverTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @param k A parameter to the heuristic, which must be positive. Typical good values are in the
    *     interval [1.0, 4.0] but it is not limited to that interval.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public WeightedCostOverTime(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
-    data = problem.getInstanceData();
+  public WeightedCostOverTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -67,11 +69,13 @@ public final class WeightedCostOverTime extends WeightedShortestProcessingTime {
   /**
    * Constructs an WeightedCostOverTime heuristic. Uses a default of k=2.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedCostOverTime(SingleMachineSchedulingProblem problem) {
-    this(problem, 2.0);
+  public WeightedCostOverTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 2.0);
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
@@ -54,15 +54,18 @@ public final class WeightedCostOverTimeSetupAdjusted
   /**
    * Constructs an WeightedCostOverTimeSetupAdjusted heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
+   * @param data The instance specific data.
    * @param k A parameter to the heuristic, which must be positive. Typical good values are in the
    *     interval [1.0, 4.0] but it is not limited to that interval.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    * @throws IllegalArgumentException if k &le; 0.0.
    */
-  public WeightedCostOverTimeSetupAdjusted(SingleMachineSchedulingProblem problem, double k) {
-    super(problem);
-    data = problem.getInstanceData();
+  public WeightedCostOverTimeSetupAdjusted(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data, double k) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -73,11 +76,13 @@ public final class WeightedCostOverTimeSetupAdjusted
   /**
    * Constructs an WeightedCostOverTimeSetupAdjusted heuristic. Uses a default of k=2.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedCostOverTimeSetupAdjusted(SingleMachineSchedulingProblem problem) {
-    this(problem, 2.0);
+  public WeightedCostOverTimeSetupAdjusted(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    this(problem, data, 2.0);
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
@@ -56,7 +56,6 @@ public final class WeightedCostOverTimeSetupAdjusted
    *
    * @param problem The cost function of a scheduling problem that is the target of the heuristic.
    * @param data The instance specific data.
-   * @param data The instance specific data.
    * @param k A parameter to the heuristic, which must be positive. Typical good values are in the
    *     interval [1.0, 4.0] but it is not limited to that interval.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjusted.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -44,12 +44,12 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedCostOverTimeSetupAdjusted
     extends WeightedShortestProcessingPlusSetupTime {
 
   private final double k;
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an WeightedCostOverTimeSetupAdjusted heuristic.
@@ -62,6 +62,7 @@ public final class WeightedCostOverTimeSetupAdjusted
    */
   public WeightedCostOverTimeSetupAdjusted(SingleMachineSchedulingProblem problem, double k) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -86,7 +87,7 @@ public final class WeightedCostOverTimeSetupAdjusted
       double s = ((IncrementalTimeCalculator) incEval).slack(element, p);
       if (s > 0) {
         double ps = data.getProcessingTime(element);
-        if (HAS_SETUPS) {
+        if (data.hasSetupTimes()) {
           ps +=
               (p.size() == 0
                   ? data.getSetupTime(element)

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatio.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatio.java
@@ -52,12 +52,14 @@ public final class WeightedCriticalRatio extends WeightedShortestProcessingTime 
   /**
    * Constructs an WeightedCriticalRatio heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedCriticalRatio(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public WeightedCriticalRatio(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatio.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatio.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -44,9 +44,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedCriticalRatio extends WeightedShortestProcessingTime {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an WeightedCriticalRatio heuristic.
@@ -56,6 +57,7 @@ public final class WeightedCriticalRatio extends WeightedShortestProcessingTime 
    */
   public WeightedCriticalRatio(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjusted.java
@@ -57,12 +57,14 @@ public final class WeightedCriticalRatioSetupAdjusted
   /**
    * Constructs an WeightedCriticalRatioSetupAdjusted heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedCriticalRatioSetupAdjusted(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public WeightedCriticalRatioSetupAdjusted(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjusted.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjusted.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -48,10 +48,11 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedCriticalRatioSetupAdjusted
     extends WeightedShortestProcessingPlusSetupTime {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an WeightedCriticalRatioSetupAdjusted heuristic.
@@ -61,6 +62,7 @@ public final class WeightedCriticalRatioSetupAdjusted
    */
   public WeightedCriticalRatioSetupAdjusted(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
     if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
@@ -73,7 +75,7 @@ public final class WeightedCriticalRatioSetupAdjusted
       double s = ((IncrementalTimeCalculator) incEval).slack(element, p);
       if (s > 0) {
         double denominator = data.getProcessingTime(element);
-        if (HAS_SETUPS) {
+        if (data.hasSetupTimes()) {
           denominator +=
               (p.size() == 0
                   ? data.getSetupTime(element)

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedEarlinessTardiness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedEarlinessTardiness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -34,7 +34,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedEarlinessTardiness implements SingleMachineSchedulingProblem {
 
@@ -52,11 +51,6 @@ public final class WeightedEarlinessTardiness implements SingleMachineScheduling
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedFlowtime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedFlowtime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -30,7 +30,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedFlowtime implements SingleMachineSchedulingProblem {
 
@@ -43,11 +42,6 @@ public final class WeightedFlowtime implements SingleMachineSchedulingProblem {
    */
   public WeightedFlowtime(SingleMachineSchedulingProblemData instanceData) {
     this.instanceData = instanceData;
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedLateness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedLateness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedLateness implements SingleMachineSchedulingProblem {
 
@@ -48,11 +47,6 @@ public final class WeightedLateness implements SingleMachineSchedulingProblem {
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTime.java
@@ -46,11 +46,12 @@ public final class WeightedLongestProcessingTime extends SchedulingHeuristic {
   /**
    * Constructs a WeightedLongestProcessingTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public WeightedLongestProcessingTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public WeightedLongestProcessingTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     // pre-compute h and cache results.
     h = new double[data.numberOfJobs()];
     double minimum = 0;

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -38,7 +38,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.12.2020
  */
 public final class WeightedLongestProcessingTime extends SchedulingHeuristic {
 
@@ -51,6 +50,7 @@ public final class WeightedLongestProcessingTime extends SchedulingHeuristic {
    */
   public WeightedLongestProcessingTime(SingleMachineSchedulingProblem problem) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     // pre-compute h and cache results.
     h = new double[data.numberOfJobs()];
     double minimum = 0;

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedNumberTardyJobs.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedNumberTardyJobs.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedNumberTardyJobs implements SingleMachineSchedulingProblem {
 
@@ -48,11 +47,6 @@ public final class WeightedNumberTardyJobs implements SingleMachineSchedulingPro
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -49,9 +49,10 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 2.22.2021
  */
 public class WeightedShortestProcessingPlusSetupTime extends SchedulingHeuristic {
+
+  private final SingleMachineSchedulingProblemData data;
 
   /**
    * Constructs an WeightedShortestProcessingPlusSetupTime heuristic.
@@ -60,6 +61,7 @@ public class WeightedShortestProcessingPlusSetupTime extends SchedulingHeuristic
    */
   public WeightedShortestProcessingPlusSetupTime(SingleMachineSchedulingProblem problem) {
     super(problem);
+    data = problem.getInstanceData();
   }
 
   @Override
@@ -67,7 +69,7 @@ public class WeightedShortestProcessingPlusSetupTime extends SchedulingHeuristic
     double value = data.getWeight(element);
     if (value < MIN_H) return MIN_H;
     double denominator = data.getProcessingTime(element);
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       denominator +=
           (p.size() == 0 ? data.getSetupTime(element) : data.getSetupTime(p.getLast(), element));
     }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTime.java
@@ -57,11 +57,13 @@ public class WeightedShortestProcessingPlusSetupTime extends SchedulingHeuristic
   /**
    * Constructs an WeightedShortestProcessingPlusSetupTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public WeightedShortestProcessingPlusSetupTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    data = problem.getInstanceData();
+  public WeightedShortestProcessingPlusSetupTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    this.data = data;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnly.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnly.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -34,7 +34,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedShortestProcessingPlusSetupTimeLateOnly
     extends WeightedShortestProcessingPlusSetupTime {
@@ -47,7 +46,7 @@ public final class WeightedShortestProcessingPlusSetupTimeLateOnly
    */
   public WeightedShortestProcessingPlusSetupTimeLateOnly(SingleMachineSchedulingProblem problem) {
     super(problem);
-    if (!data.hasDueDates()) {
+    if (!problem.getInstanceData().hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
   }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnly.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnly.java
@@ -41,12 +41,14 @@ public final class WeightedShortestProcessingPlusSetupTimeLateOnly
   /**
    * Constructs an WeightedShortestProcessingPlusSetupTimeLateOnly heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedShortestProcessingPlusSetupTimeLateOnly(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    if (!problem.getInstanceData().hasDueDates()) {
+  public WeightedShortestProcessingPlusSetupTimeLateOnly(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
   }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecompute.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2021  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -49,7 +49,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.11.2021
  */
 public class WeightedShortestProcessingPlusSetupTimePrecompute extends SchedulingHeuristic {
 
@@ -62,9 +61,10 @@ public class WeightedShortestProcessingPlusSetupTimePrecompute extends Schedulin
    */
   public WeightedShortestProcessingPlusSetupTimePrecompute(SingleMachineSchedulingProblem problem) {
     super(problem);
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     final int n = data.numberOfJobs();
     h = new double[n][n];
-    if (HAS_SETUPS) {
+    if (data.hasSetupTimes()) {
       for (int i = 0; i < n; i++) {
         h[i][i] =
             Math.max(

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecompute.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecompute.java
@@ -57,11 +57,12 @@ public class WeightedShortestProcessingPlusSetupTimePrecompute extends Schedulin
   /**
    * Constructs an WeightedShortestProcessingPlusSetupTimePrecompute heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public WeightedShortestProcessingPlusSetupTimePrecompute(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
+  public WeightedShortestProcessingPlusSetupTimePrecompute(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     final int n = data.numberOfJobs();
     h = new double[n][n];
     if (data.hasSetupTimes()) {

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTime.java
@@ -43,12 +43,13 @@ public class WeightedShortestProcessingTime extends SchedulingHeuristic {
   /**
    * Constructs an WeightedShortestProcessingTime heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    */
-  public WeightedShortestProcessingTime(SingleMachineSchedulingProblem problem) {
-    super(problem);
+  public WeightedShortestProcessingTime(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
     // pre-compute h and cache results.
-    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     h = new double[data.numberOfJobs()];
     for (int i = 0; i < h.length; i++) {
       h[i] = data.getWeight(i);

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTime.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTime.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -35,7 +35,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public class WeightedShortestProcessingTime extends SchedulingHeuristic {
 
@@ -49,6 +48,7 @@ public class WeightedShortestProcessingTime extends SchedulingHeuristic {
   public WeightedShortestProcessingTime(SingleMachineSchedulingProblem problem) {
     super(problem);
     // pre-compute h and cache results.
+    SingleMachineSchedulingProblemData data = problem.getInstanceData();
     h = new double[data.numberOfJobs()];
     for (int i = 0; i < h.length; i++) {
       h[i] = data.getWeight(i);

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnly.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnly.java
@@ -46,12 +46,14 @@ public final class WeightedShortestProcessingTimeLateOnly extends WeightedShorte
   /**
    * Constructs an WeightedShortestProcessingTimeLateOnly heuristic.
    *
-   * @param problem The instance of a scheduling problem that is the target of the heuristic.
+   * @param problem The cost function of a scheduling problem that is the target of the heuristic.
+   * @param data The instance specific data.
    * @throws IllegalArgumentException if problem.hasDueDates() returns false.
    */
-  public WeightedShortestProcessingTimeLateOnly(SingleMachineSchedulingProblem problem) {
-    super(problem);
-    if (!problem.getInstanceData().hasDueDates()) {
+  public WeightedShortestProcessingTimeLateOnly(
+      SingleMachineSchedulingProblem problem, SingleMachineSchedulingProblemData data) {
+    super(problem, data);
+    if (!data.hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
   }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnly.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnly.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -40,7 +40,6 @@ import org.cicirello.search.ss.Partial;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 9.4.2020
  */
 public final class WeightedShortestProcessingTimeLateOnly extends WeightedShortestProcessingTime {
 
@@ -52,7 +51,7 @@ public final class WeightedShortestProcessingTimeLateOnly extends WeightedShorte
    */
   public WeightedShortestProcessingTimeLateOnly(SingleMachineSchedulingProblem problem) {
     super(problem);
-    if (!data.hasDueDates()) {
+    if (!problem.getInstanceData().hasDueDates()) {
       throw new IllegalArgumentException("This heuristic requires due dates.");
     }
   }

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedSquaredTardiness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedSquaredTardiness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,7 +32,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedSquaredTardiness implements SingleMachineSchedulingProblem {
 
@@ -49,11 +48,6 @@ public final class WeightedSquaredTardiness implements SingleMachineSchedulingPr
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/main/java/org/cicirello/search/problems/scheduling/WeightedTardiness.java
+++ b/src/main/java/org/cicirello/search/problems/scheduling/WeightedTardiness.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,7 +32,6 @@ import org.cicirello.permutations.Permutation;
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 7.15.2020
  */
 public final class WeightedTardiness implements SingleMachineSchedulingProblem {
 
@@ -49,11 +48,6 @@ public final class WeightedTardiness implements SingleMachineSchedulingProblem {
     if (!instanceData.hasDueDates()) {
       throw new IllegalArgumentException("This cost function requires due dates.");
     }
-  }
-
-  @Override
-  public SingleMachineSchedulingProblemData getInstanceData() {
-    return instanceData;
   }
 
   @Override

--- a/src/test/java/org/cicirello/search/problems/scheduling/ATCSTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ATCSTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -50,7 +50,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All late tests, k1=2, k2=7?shouldn't matter
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    ATCS h = new ATCS(problem, 2, 7);
+    ATCS h = new ATCS(problem, problem.getData(), 2, 7);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -58,7 +58,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k1=2, k2=7?shouldn't matter
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ATCS(problem, 2, 7);
+    h = new ATCS(problem, problem.getData(), 2, 7);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -69,7 +69,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4, k2=7?shouldn't matter
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ATCS(problem, 4, 7);
+    h = new ATCS(problem, problem.getData(), 4, 7);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -86,16 +86,26 @@ public class ATCSTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new ATCS(pr, 1, 1);
+              new ATCS(pr, pr.getData(), 1, 1);
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ATCS(new FakeProblemWeightsPTime(w, p, 0), 0.0, 0.001));
+            () ->
+                new ATCS(
+                    new FakeProblemWeightsPTime(w, p, 0),
+                    new FakeProblemData(w, p, 0),
+                    0.0,
+                    0.001));
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ATCS(new FakeProblemWeightsPTime(w, p, 0), 0.001, 0.0));
+            () ->
+                new ATCS(
+                    new FakeProblemWeightsPTime(w, p, 0),
+                    new FakeProblemData(w, p, 0),
+                    0.001,
+                    0.0));
   }
 
   @Test
@@ -116,7 +126,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     PartialPermutation partial = new PartialPermutation(expected0.length);
     // All late tests, k1=2, k2=1
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
-    ATCS h = new ATCS(problem, 2, 1);
+    ATCS h = new ATCS(problem, problem.getData(), 2, 1);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     double sAve = h.getSetupAverage();
     for (int j = 1; j < expected0.length; j++) {
@@ -126,7 +136,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k1=2, k2=2
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new ATCS(problem, 2, 2);
+    h = new ATCS(problem, problem.getData(), 2, 2);
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       double correction = Math.exp(-0.5 * slack[j] / pAve) * Math.exp(-2.0 / sAve);
@@ -136,7 +146,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4, k2=3
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new ATCS(problem, 4, 3);
+    h = new ATCS(problem, problem.getData(), 4, 3);
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       double correction = Math.exp(-0.25 * slack[j] / pAve) * Math.exp(-4.0 / 3.0 / sAve);
@@ -165,7 +175,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     PartialPermutation partial = new PartialPermutation(expected0.length);
     // All late tests,
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
-    ATCS h = new ATCS(problem);
+    ATCS h = new ATCS(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     double sAve = h.getSetupAverage();
     for (int j = 1; j < expected0.length; j++) {
@@ -173,14 +183,14 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20,
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
     }
     // d=all different,
     problem = new FakeProblemWeightsPTime(w, p, dates, 4);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -188,7 +198,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     // wider duedate range
     int[] dw = {20, highP * 2, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w, p, dw, 4);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -196,7 +206,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     // extremely wide duedate range
     int[] dew = {20, highP * 4, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w, p, dew, 4);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -213,7 +223,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
       {10, 2, 1, 7}
     };
     problem = new FakeProblemWeightsPTime(w0, p0, d0, setups);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -227,7 +237,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     };
     int[] dlow = {20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w0, p0, dlow, sLowVar);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -240,7 +250,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
       {0, 0, 0, 0}
     };
     problem = new FakeProblemWeightsPTime(w0, p0, dlow, setupZero);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -261,7 +271,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     }
     s1[0][0] = 11;
     problem = new FakeProblemWeightsPTime(w1, p1, d1, s1);
-    h = new ATCS(problem);
+    h = new ATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -274,7 +284,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new ATCS(pr);
+              new ATCS(pr, pr.getData());
             });
   }
 
@@ -290,7 +300,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
       999, Math.exp(-1), 0.5 * Math.exp(-0.5), 0.25 * Math.exp(-8.0 / 3), 0.125 * Math.exp(-5.0 / 6)
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    ATCS h = new ATCS(problem, 2.0, 3.0);
+    ATCS h = new ATCS(problem, problem.getData(), 2.0, 3.0);
     PartialPermutation partial = new PartialPermutation(expected0.length);
     partial.extend(0);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
@@ -304,7 +314,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     double k = 0.5 / Math.log(1.0 / e);
     int due = 2;
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, due);
-    h = new ATCS(problem, k, 1);
+    h = new ATCS(problem, problem.getData(), k, 1);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -312,7 +322,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     // force small heuristic case with k2
     int[][] sets = {{1}};
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, new int[] {due}, sets);
-    h = new ATCS(problem, 1, k);
+    h = new ATCS(problem, problem.getData(), 1, k);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -338,7 +348,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
       999, Math.exp(-1), 0.5 * Math.exp(-0.5), 0.25 * Math.exp(-8.0 / 3), 0.125 * Math.exp(-5.0 / 6)
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    ATCS h = new ATCS(problem, 2.0, 3.0);
+    ATCS h = new ATCS(problem, problem.getData(), 2.0, 3.0);
     PartialPermutation partial = new PartialPermutation(expected0.length);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
@@ -367,7 +377,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
       999, Math.exp(-1), 0.5 * Math.exp(-0.5), 0.25 * Math.exp(-8.0 / 3), 0.125 * Math.exp(-5.0 / 6)
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    ATCS h = new ATCS(problem, 2.0, 3.0);
+    ATCS h = new ATCS(problem, problem.getData(), 2.0, 3.0);
     PartialPermutation partial = new PartialPermutation(expected0.length);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);

--- a/src/test/java/org/cicirello/search/problems/scheduling/ATCSTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ATCSTests.java
@@ -128,7 +128,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
     ATCS h = new ATCS(problem, problem.getData(), 2, 1);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
-    double sAve = h.getSetupAverage();
+    double sAve = problem.getData().sumOfSetupTimes() / (1.0 * p.length * p.length);
     for (int j = 1; j < expected0.length; j++) {
       double correction = expected0[j] * Math.exp(-4.0 / sAve);
       assertEquals(
@@ -177,7 +177,7 @@ public class ATCSTests extends SchedulingHeuristicValidation {
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
     ATCS h = new ATCS(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
-    double sAve = h.getSetupAverage();
+    double sAve = problem.getData().sumOfSetupTimes() / (1.0 * p.length * p.length);
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "negativeSlack, j:" + j);
     }

--- a/src/test/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjustedTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostSetupAdjustedTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -49,7 +49,8 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    ApparentTardinessCostSetupAdjusted h = new ApparentTardinessCostSetupAdjusted(problem);
+    ApparentTardinessCostSetupAdjusted h =
+        new ApparentTardinessCostSetupAdjusted(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -57,7 +58,7 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ApparentTardinessCostSetupAdjusted(problem);
+    h = new ApparentTardinessCostSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -68,7 +69,7 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ApparentTardinessCostSetupAdjusted(problem, 4);
+    h = new ApparentTardinessCostSetupAdjusted(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -83,7 +84,7 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     double k = 0.5 / Math.log(1.0 / e);
     int d = 2;
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, d);
-    h = new ApparentTardinessCostSetupAdjusted(problem, k);
+    h = new ApparentTardinessCostSetupAdjusted(problem, problem.getData(), k);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -95,12 +96,14 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new ApparentTardinessCostSetupAdjusted(pr);
+              new ApparentTardinessCostSetupAdjusted(pr, pr.getData());
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ApparentTardinessCostSetupAdjusted(new FakeProblemWeightsPTime(w, p, 0), 0));
+            () ->
+                new ApparentTardinessCostSetupAdjusted(
+                    new FakeProblemWeightsPTime(w, p, 0), new FakeProblemData(w, p, 0), 0));
   }
 
   @Test
@@ -122,7 +125,8 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 1);
-    ApparentTardinessCostSetupAdjusted h = new ApparentTardinessCostSetupAdjusted(problem);
+    ApparentTardinessCostSetupAdjusted h =
+        new ApparentTardinessCostSetupAdjusted(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -130,7 +134,7 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20, 1);
-    h = new ApparentTardinessCostSetupAdjusted(problem);
+    h = new ApparentTardinessCostSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -141,7 +145,7 @@ public class ApparentTardinessCostSetupAdjustedTests extends SchedulingHeuristic
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20, 1);
-    h = new ApparentTardinessCostSetupAdjusted(problem, 4);
+    h = new ApparentTardinessCostSetupAdjusted(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {

--- a/src/test/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ApparentTardinessCostTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -49,7 +49,7 @@ public class ApparentTardinessCostTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    ApparentTardinessCost h = new ApparentTardinessCost(problem);
+    ApparentTardinessCost h = new ApparentTardinessCost(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -57,7 +57,7 @@ public class ApparentTardinessCostTests extends SchedulingHeuristicValidation {
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ApparentTardinessCost(problem);
+    h = new ApparentTardinessCost(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -68,7 +68,7 @@ public class ApparentTardinessCostTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new ApparentTardinessCost(problem, 4);
+    h = new ApparentTardinessCost(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -83,7 +83,7 @@ public class ApparentTardinessCostTests extends SchedulingHeuristicValidation {
     double k = 0.5 / Math.log(1.0 / e);
     int d = 2;
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, d);
-    h = new ApparentTardinessCost(problem, k);
+    h = new ApparentTardinessCost(problem, problem.getData(), k);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -95,11 +95,13 @@ public class ApparentTardinessCostTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new ApparentTardinessCost(pr);
+              new ApparentTardinessCost(pr, pr.getData());
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ApparentTardinessCost(new FakeProblemWeightsPTime(w, p, 0), 0));
+            () ->
+                new ApparentTardinessCost(
+                    new FakeProblemWeightsPTime(w, p, 0), new FakeProblemData(w, p, 0), 0));
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/CostFunctionTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/CostFunctionTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -39,7 +39,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d, w);
     WeightedLateness costFunction = new WeightedLateness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(37, costFunction.cost(p1));
     assertEquals(-51, costFunction.cost(p2));
     assertEquals(37, costFunction.value(p1));
@@ -81,7 +80,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d, w);
     WeightedTardiness costFunction = new WeightedTardiness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(46, costFunction.cost(p1));
     assertEquals(68, costFunction.cost(p2));
     assertEquals(46, costFunction.value(p1));
@@ -122,7 +120,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d, w, we);
     WeightedEarlinessTardiness costFunction = new WeightedEarlinessTardiness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(58, costFunction.cost(p1));
     assertEquals(263, costFunction.cost(p2));
     assertEquals(58, costFunction.value(p1));
@@ -162,7 +159,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d, w);
     WeightedNumberTardyJobs costFunction = new WeightedNumberTardyJobs(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(11, costFunction.cost(p1));
     assertEquals(6, costFunction.cost(p2));
     assertEquals(11, costFunction.value(p1));
@@ -202,7 +198,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d, w);
     WeightedSquaredTardiness costFunction = new WeightedSquaredTardiness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(332, costFunction.cost(p1));
     assertEquals(904, costFunction.cost(p2));
     assertEquals(332, costFunction.value(p1));
@@ -241,7 +236,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d);
     MinimizeMaximumLateness costFunction = new MinimizeMaximumLateness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(10, costFunction.cost(p1));
     assertEquals(18, costFunction.cost(p2));
     assertEquals(10, costFunction.value(p1));
@@ -292,7 +286,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noR = new TestScheduleData(p);
     MinimizeMaximumFlowtime costFunction = new MinimizeMaximumFlowtime(noR);
-    assertEquals(noR, costFunction.getInstanceData());
     assertEquals(28, costFunction.cost(p1));
     assertEquals(28, costFunction.cost(p2));
     assertEquals(28, costFunction.value(p1));
@@ -321,7 +314,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noR = new TestScheduleData(p, (int[]) null, w);
     WeightedFlowtime costFunction = new WeightedFlowtime(noR);
-    assertEquals(noR, costFunction.getInstanceData());
     assertEquals(170, costFunction.cost(p1));
     assertEquals(133, costFunction.cost(p2));
     assertEquals(170, costFunction.value(p1));
@@ -347,7 +339,6 @@ public class CostFunctionTests {
     Permutation p2 = new Permutation(dec);
     TestScheduleData noS = new TestScheduleData(p, d);
     MinimizeMaximumTardiness costFunction = new MinimizeMaximumTardiness(noS);
-    assertEquals(noS, costFunction.getInstanceData());
     assertEquals(10, costFunction.cost(p1));
     assertEquals(18, costFunction.cost(p2));
     assertEquals(10, costFunction.value(p1));
@@ -400,7 +391,6 @@ public class CostFunctionTests {
       Permutation p2 = new Permutation(revOrder);
       TestScheduleData onlyP = new TestScheduleData(p);
       MinimizeMakespan costFunction = new MinimizeMakespan(onlyP);
-      assertEquals(onlyP, costFunction.getInstanceData());
       int expected = n + (n + 1) * n / 2;
       assertEquals(expected, costFunction.cost(p1));
       assertEquals(expected, costFunction.cost(p2));

--- a/src/test/java/org/cicirello/search/problems/scheduling/DynamicATCSTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/DynamicATCSTests.java
@@ -42,7 +42,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
       {8, 1, 2, 3}
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    DynamicATCS h = new DynamicATCS(problem, 2, 1);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData(), 2, 1);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     DynamicATCS.IncrementalStatsCalculator incATCS = (DynamicATCS.IncrementalStatsCalculator) inc;
     assertEquals(58.0 / 16, incATCS.averageSetupTime(), 1E-10);
@@ -80,7 +80,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All late tests, k1=2, k2=7?shouldn't matter
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    DynamicATCS h = new DynamicATCS(problem, 2, 7);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData(), 2, 7);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -88,7 +88,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k1=2, k2=7?shouldn't matter
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new DynamicATCS(problem, 2, 7);
+    h = new DynamicATCS(problem, problem.getData(), 2, 7);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -99,7 +99,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4, k2=7?shouldn't matter
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new DynamicATCS(problem, 4, 7);
+    h = new DynamicATCS(problem, problem.getData(), 4, 7);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -116,16 +116,26 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new DynamicATCS(pr, 1, 1);
+              new DynamicATCS(pr, pr.getData(), 1, 1);
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new DynamicATCS(new FakeProblemWeightsPTime(w, p, 0), 0.0, 0.001));
+            () ->
+                new DynamicATCS(
+                    new FakeProblemWeightsPTime(w, p, 0),
+                    new FakeProblemData(w, p, 0),
+                    0.0,
+                    0.001));
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new DynamicATCS(new FakeProblemWeightsPTime(w, p, 0), 0.001, 0.0));
+            () ->
+                new DynamicATCS(
+                    new FakeProblemWeightsPTime(w, p, 0),
+                    new FakeProblemData(w, p, 0),
+                    0.001,
+                    0.0));
   }
 
   @Test
@@ -146,7 +156,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     PartialPermutation partial = new PartialPermutation(expected0.length);
     // All late tests, k1=2, k2=1
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
-    DynamicATCS h = new DynamicATCS(problem, 2, 1);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData(), 2, 1);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     double sAve = ((DynamicATCS.IncrementalStatsCalculator) inc).averageSetupTime();
     for (int j = 1; j < expected0.length; j++) {
@@ -156,7 +166,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k1=2, k2=2
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new DynamicATCS(problem, 2, 2);
+    h = new DynamicATCS(problem, problem.getData(), 2, 2);
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       double correction = Math.exp(-0.5 * slack[j] / pAve) * Math.exp(-2.0 / sAve);
@@ -166,7 +176,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4, k2=3
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new DynamicATCS(problem, 4, 3);
+    h = new DynamicATCS(problem, problem.getData(), 4, 3);
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       double correction = Math.exp(-0.25 * slack[j] / pAve) * Math.exp(-4.0 / 3.0 / sAve);
@@ -194,7 +204,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     PartialPermutation partial = new PartialPermutation(expected0.length);
     // All late tests,
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 4);
-    DynamicATCS h = new DynamicATCS(problem);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     double sAve = ((DynamicATCS.IncrementalStatsCalculator) inc).averageSetupTime();
     for (int j = 1; j < expected0.length; j++) {
@@ -202,7 +212,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     // d=20,
     problem = new FakeProblemWeightsPTime(w, p, 20, 4);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -210,7 +220,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     // d=all different,
     int[] dates = {30, 25, 20, 45, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22};
     problem = new FakeProblemWeightsPTime(w, p, dates, 4);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -218,7 +228,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     // wider duedate range
     int[] dw = {20, highP * 2, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w, p, dw, 4);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -226,7 +236,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     // extremely wide duedate range
     int[] dew = {20, highP * 4, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w, p, dew, 4);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 1; j < expected0.length; j++) {
       assertTrue(expected0[j] >= h.h(partial, j, inc), "positiveSlack, j:" + j);
@@ -243,7 +253,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
       {10, 2, 1, 7}
     };
     problem = new FakeProblemWeightsPTime(w0, p0, d0, setups);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -257,7 +267,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     };
     int[] dlow = {20, 20, 20, 20};
     problem = new FakeProblemWeightsPTime(w0, p0, dlow, sLowVar);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -270,7 +280,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
       {0, 0, 0, 0}
     };
     problem = new FakeProblemWeightsPTime(w0, p0, dlow, setupZero);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -291,7 +301,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     }
     s1[0][0] = 11;
     problem = new FakeProblemWeightsPTime(w1, p1, d1, s1);
-    h = new DynamicATCS(problem);
+    h = new DynamicATCS(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < e0.length; j++) {
       assertTrue(e0[j] >= h.h(partial, j, inc));
@@ -304,7 +314,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new DynamicATCS(pr);
+              new DynamicATCS(pr, pr.getData());
             });
   }
 
@@ -320,7 +330,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
       999, Math.exp(-1), 0.5 * Math.exp(-0.5), 0.25 * Math.exp(-8.0 / 3), 0.125 * Math.exp(-5.0 / 6)
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    DynamicATCS h = new DynamicATCS(problem, 2.0, 3.0);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData(), 2.0, 3.0);
     PartialPermutation partial = new PartialPermutation(expected0.length);
     partial.extend(0);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
@@ -334,7 +344,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     double k = 0.5 / Math.log(1.0 / e);
     int due = 2;
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, due);
-    h = new DynamicATCS(problem, k, 1);
+    h = new DynamicATCS(problem, problem.getData(), k, 1);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -342,7 +352,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
     // force small heuristic case with k2
     int[][] sets = {{1}};
     problem = new FakeProblemWeightsPTime(new int[] {wp}, new int[] {wp}, new int[] {due}, sets);
-    h = new DynamicATCS(problem, 1, k);
+    h = new DynamicATCS(problem, problem.getData(), 1, k);
     inc = h.createIncrementalEvaluation();
     partial = new PartialPermutation(1);
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -366,7 +376,7 @@ public class DynamicATCSTests extends SchedulingHeuristicValidation {
       999, Math.exp(-1), 0.5 * Math.exp(-0.5), 0.25 * Math.exp(-8.0 / 3), 0.125 * Math.exp(-5.0 / 6)
     };
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, d, s);
-    DynamicATCS h = new DynamicATCS(problem, 2.0, 3.0);
+    DynamicATCS h = new DynamicATCS(problem, problem.getData(), 2.0, 3.0);
     PartialPermutation partial = new PartialPermutation(d.length);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);

--- a/src/test/java/org/cicirello/search/problems/scheduling/EarliestDueDateTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/EarliestDueDateTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,7 +32,7 @@ public class EarliestDueDateTests extends SchedulingHeuristicValidation {
     int[] duedates = {3, 0, 1, 7, (int) Math.ceil(2.0 / EarliestDueDate.MIN_H - 1.0)};
     double[] expected = {0.25, 1.0, 0.5, 0.125, EarliestDueDate.MIN_H};
     FakeProblemDuedates problem = new FakeProblemDuedates(duedates);
-    EarliestDueDate h = new EarliestDueDate(problem);
+    EarliestDueDate h = new EarliestDueDate(problem, problem.getData());
     for (int j = 0; j < duedates.length; j++) {
       assertEquals(expected[j], h.h(null, j, null), 1E-10);
     }
@@ -43,7 +43,7 @@ public class EarliestDueDateTests extends SchedulingHeuristicValidation {
               int[] p = {1, 1};
               int[] w = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p, w);
-              new EarliestDueDate(pr);
+              new EarliestDueDate(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristicTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ExponentialEarlyTardyHeuristicTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -55,8 +55,8 @@ public class ExponentialEarlyTardyHeuristicTests extends SchedulingHeuristicVali
         FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
         ExponentialEarlyTardyHeuristic h =
             k == 1
-                ? new ExponentialEarlyTardyHeuristic(problem)
-                : new ExponentialEarlyTardyHeuristic(problem, k);
+                ? new ExponentialEarlyTardyHeuristic(problem, problem.getData())
+                : new ExponentialEarlyTardyHeuristic(problem, problem.getData(), k);
         IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
         PartialPermutation partial = new PartialPermutation(p.length);
         for (int j = 0; j < expected.length; j++) {
@@ -87,8 +87,8 @@ public class ExponentialEarlyTardyHeuristicTests extends SchedulingHeuristicVali
         FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
         ExponentialEarlyTardyHeuristic h =
             k == 1
-                ? new ExponentialEarlyTardyHeuristic(problem)
-                : new ExponentialEarlyTardyHeuristic(problem, k);
+                ? new ExponentialEarlyTardyHeuristic(problem, problem.getData())
+                : new ExponentialEarlyTardyHeuristic(problem, problem.getData(), k);
         IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
         PartialPermutation partial = new PartialPermutation(p.length);
         for (int j = 0; j < expected.length; j++) {
@@ -115,7 +115,8 @@ public class ExponentialEarlyTardyHeuristicTests extends SchedulingHeuristicVali
       expected[i] += e + 2;
     }
     FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
-    ExponentialEarlyTardyHeuristic h = new ExponentialEarlyTardyHeuristic(problem, k);
+    ExponentialEarlyTardyHeuristic h =
+        new ExponentialEarlyTardyHeuristic(problem, problem.getData(), k);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     PartialPermutation partial = new PartialPermutation(p.length);
     for (int j = 0; j < expected.length; j++) {
@@ -143,7 +144,8 @@ public class ExponentialEarlyTardyHeuristicTests extends SchedulingHeuristicVali
       expected[i] += e + 2;
     }
     FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
-    ExponentialEarlyTardyHeuristic h = new ExponentialEarlyTardyHeuristic(problem, k);
+    ExponentialEarlyTardyHeuristic h =
+        new ExponentialEarlyTardyHeuristic(problem, problem.getData(), k);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     PartialPermutation partial = new PartialPermutation(p.length);
     for (int j = 0; j < expected.length; j++) {
@@ -159,6 +161,7 @@ public class ExponentialEarlyTardyHeuristicTests extends SchedulingHeuristicVali
             () ->
                 new ExponentialEarlyTardyHeuristic(
                     new FakeEarlyTardyProblem(new int[1], new int[1], new int[1], new int[1]),
+                    new FakeEarlyTardyProblemData(new int[1], new int[1], new int[1], new int[1]),
                     0.9999));
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/InterfaceDefaultMethodsTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/InterfaceDefaultMethodsTests.java
@@ -61,6 +61,7 @@ public class InterfaceDefaultMethodsTests {
 
     UnsupportedOperationException thrown =
         assertThrows(UnsupportedOperationException.class, () -> data.getDueDate(0));
+    thrown = assertThrows(UnsupportedOperationException.class, () -> data.dueDateStats());
   }
 
   @Test
@@ -93,6 +94,144 @@ public class InterfaceDefaultMethodsTests {
     assertEquals(0, data.getSetupTime(0, 1));
     assertEquals(18, data.sumOfProcessingTimes());
     assertEquals(0, data.sumOfSetupTimes());
+
+    UnsupportedOperationException thrown =
+        assertThrows(UnsupportedOperationException.class, () -> data.dueDateStats());
+  }
+
+  @Test
+  public void testSingleMachineSchedulingProblemData_duedates1() {
+
+    SingleMachineSchedulingProblemData data =
+        new SingleMachineSchedulingProblemData() {
+          public int numberOfJobs() {
+            return 3;
+          }
+
+          public int getProcessingTime(int j) {
+            return (j + 1) * 3;
+          }
+
+          public int[] getCompletionTimes(Permutation schedule) {
+            return null;
+          }
+
+          public int getDueDate(int j) {
+            return (j + 1) * 10;
+          }
+
+          public boolean hasDueDates() {
+            return true;
+          }
+        };
+
+    assertTrue(data.hasDueDates());
+    assertFalse(data.hasReleaseDates());
+    assertFalse(data.hasWeights());
+    assertFalse(data.hasEarlyWeights());
+    assertFalse(data.hasSetupTimes());
+    assertEquals(0, data.getReleaseDate(0));
+    assertEquals(1, data.getWeight(0));
+    assertEquals(1, data.getEarlyWeight(0));
+    assertEquals(0, data.getSetupTime(0));
+    assertEquals(0, data.getSetupTime(0, 1));
+    assertEquals(18, data.sumOfProcessingTimes());
+    assertEquals(0, data.sumOfSetupTimes());
+    double[] ddStats = data.dueDateStats();
+    assertEquals(3, ddStats.length);
+    assertEquals(10, ddStats[0]);
+    assertEquals(30, ddStats[1]);
+    assertEquals(20, ddStats[2]);
+  }
+
+  @Test
+  public void testSingleMachineSchedulingProblemData_duedates2() {
+
+    SingleMachineSchedulingProblemData data =
+        new SingleMachineSchedulingProblemData() {
+          public int numberOfJobs() {
+            return 3;
+          }
+
+          public int getProcessingTime(int j) {
+            return (j + 1) * 3;
+          }
+
+          public int[] getCompletionTimes(Permutation schedule) {
+            return null;
+          }
+
+          public int getDueDate(int j) {
+            return (3 - j) * 10;
+          }
+
+          public boolean hasDueDates() {
+            return true;
+          }
+        };
+
+    assertTrue(data.hasDueDates());
+    assertFalse(data.hasReleaseDates());
+    assertFalse(data.hasWeights());
+    assertFalse(data.hasEarlyWeights());
+    assertFalse(data.hasSetupTimes());
+    assertEquals(0, data.getReleaseDate(0));
+    assertEquals(1, data.getWeight(0));
+    assertEquals(1, data.getEarlyWeight(0));
+    assertEquals(0, data.getSetupTime(0));
+    assertEquals(0, data.getSetupTime(0, 1));
+    assertEquals(18, data.sumOfProcessingTimes());
+    assertEquals(0, data.sumOfSetupTimes());
+    double[] ddStats = data.dueDateStats();
+    assertEquals(3, ddStats.length);
+    assertEquals(10, ddStats[0]);
+    assertEquals(30, ddStats[1]);
+    assertEquals(20, ddStats[2]);
+  }
+
+  @Test
+  public void testSingleMachineSchedulingProblemData_duedates3() {
+
+    SingleMachineSchedulingProblemData data =
+        new SingleMachineSchedulingProblemData() {
+          public int numberOfJobs() {
+            return 3;
+          }
+
+          public int getProcessingTime(int j) {
+            return (j + 1) * 3;
+          }
+
+          public int[] getCompletionTimes(Permutation schedule) {
+            return null;
+          }
+
+          public int getDueDate(int j) {
+            return 25;
+          }
+
+          public boolean hasDueDates() {
+            return true;
+          }
+        };
+
+    assertTrue(data.hasDueDates());
+    assertFalse(data.hasReleaseDates());
+    assertFalse(data.hasWeights());
+    assertFalse(data.hasEarlyWeights());
+    assertFalse(data.hasSetupTimes());
+    assertEquals(0, data.getReleaseDate(0));
+    assertEquals(1, data.getWeight(0));
+    assertEquals(1, data.getEarlyWeight(0));
+    assertEquals(0, data.getSetupTime(0));
+    assertEquals(0, data.getSetupTime(0, 1));
+    assertEquals(18, data.sumOfProcessingTimes());
+    assertEquals(0, data.sumOfSetupTimes());
+    double[] ddStats = data.dueDateStats();
+    assertEquals(3, ddStats.length);
+    assertEquals(25, ddStats[0]);
+    assertEquals(25, ddStats[1]);
+    assertEquals(25, ddStats[2]);
   }
 
   @Test

--- a/src/test/java/org/cicirello/search/problems/scheduling/InterfaceDefaultMethodsTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/InterfaceDefaultMethodsTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2022 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 public class InterfaceDefaultMethodsTests {
 
   @Test
-  public void testSingleMachineSchedulingProblemData() {
+  public void testSingleMachineSchedulingProblemData_0_jobs() {
 
     SingleMachineSchedulingProblemData data =
         new SingleMachineSchedulingProblemData() {
@@ -56,8 +56,93 @@ public class InterfaceDefaultMethodsTests {
     assertEquals(1, data.getEarlyWeight(0));
     assertEquals(0, data.getSetupTime(0));
     assertEquals(0, data.getSetupTime(0, 1));
+    assertEquals(0, data.sumOfProcessingTimes());
+    assertEquals(0, data.sumOfSetupTimes());
 
     UnsupportedOperationException thrown =
         assertThrows(UnsupportedOperationException.class, () -> data.getDueDate(0));
+  }
+
+  @Test
+  public void testSingleMachineSchedulingProblemData_multiple_jobs() {
+
+    SingleMachineSchedulingProblemData data =
+        new SingleMachineSchedulingProblemData() {
+          public int numberOfJobs() {
+            return 3;
+          }
+
+          public int getProcessingTime(int j) {
+            return (j + 1) * 3;
+          }
+
+          public int[] getCompletionTimes(Permutation schedule) {
+            return null;
+          }
+        };
+
+    assertFalse(data.hasDueDates());
+    assertFalse(data.hasReleaseDates());
+    assertFalse(data.hasWeights());
+    assertFalse(data.hasEarlyWeights());
+    assertFalse(data.hasSetupTimes());
+    assertEquals(0, data.getReleaseDate(0));
+    assertEquals(1, data.getWeight(0));
+    assertEquals(1, data.getEarlyWeight(0));
+    assertEquals(0, data.getSetupTime(0));
+    assertEquals(0, data.getSetupTime(0, 1));
+    assertEquals(18, data.sumOfProcessingTimes());
+    assertEquals(0, data.sumOfSetupTimes());
+  }
+
+  @Test
+  public void testSingleMachineSchedulingProblemData_setups() {
+
+    SingleMachineSchedulingProblemData data =
+        new SingleMachineSchedulingProblemData() {
+
+          private int[][] s = {
+            {6, 3, 8},
+            {4, 7, 1},
+            {9, 2, 5}
+          };
+
+          public int numberOfJobs() {
+            return 3;
+          }
+
+          public int getProcessingTime(int j) {
+            return (j + 1) * 3;
+          }
+
+          public int[] getCompletionTimes(Permutation schedule) {
+            return null;
+          }
+
+          public boolean hasSetupTimes() {
+            return true;
+          }
+
+          public int getSetupTime(int j) {
+            return s[j][j];
+          }
+
+          public int getSetupTime(int i, int j) {
+            return s[i][j];
+          }
+        };
+
+    assertFalse(data.hasDueDates());
+    assertFalse(data.hasReleaseDates());
+    assertFalse(data.hasWeights());
+    assertFalse(data.hasEarlyWeights());
+    assertTrue(data.hasSetupTimes());
+    assertEquals(0, data.getReleaseDate(0));
+    assertEquals(1, data.getWeight(0));
+    assertEquals(1, data.getEarlyWeight(0));
+    assertEquals(6, data.getSetupTime(0));
+    assertEquals(3, data.getSetupTime(0, 1));
+    assertEquals(18, data.sumOfProcessingTimes());
+    assertEquals(45, data.sumOfSetupTimes());
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristicTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/LinearEarlyTardyHeuristicTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -38,6 +38,7 @@ public class LinearEarlyTardyHeuristicTests extends SchedulingHeuristicValidatio
             () ->
                 new LinearEarlyTardyHeuristic(
                     new FakeEarlyTardyProblem(new int[1], new int[1], new int[1], new int[1]),
+                    new FakeEarlyTardyProblemData(new int[1], new int[1], new int[1], new int[1]),
                     0.9999));
   }
 
@@ -66,8 +67,8 @@ public class LinearEarlyTardyHeuristicTests extends SchedulingHeuristicValidatio
         FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
         LinearEarlyTardyHeuristic h =
             k == 1
-                ? new LinearEarlyTardyHeuristic(problem)
-                : new LinearEarlyTardyHeuristic(problem, k);
+                ? new LinearEarlyTardyHeuristic(problem, problem.getData())
+                : new LinearEarlyTardyHeuristic(problem, problem.getData(), k);
         IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
         PartialPermutation partial = new PartialPermutation(p.length);
         for (int j = 0; j < expected.length; j++) {
@@ -98,8 +99,8 @@ public class LinearEarlyTardyHeuristicTests extends SchedulingHeuristicValidatio
         FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
         LinearEarlyTardyHeuristic h =
             k == 1
-                ? new LinearEarlyTardyHeuristic(problem)
-                : new LinearEarlyTardyHeuristic(problem, k);
+                ? new LinearEarlyTardyHeuristic(problem, problem.getData())
+                : new LinearEarlyTardyHeuristic(problem, problem.getData(), k);
         IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
         PartialPermutation partial = new PartialPermutation(p.length);
         for (int j = 0; j < expected.length; j++) {
@@ -138,7 +139,7 @@ public class LinearEarlyTardyHeuristicTests extends SchedulingHeuristicValidatio
       d[i] = (dWSPT[i] + dWLPT[i]) / 2;
     }
     FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
-    LinearEarlyTardyHeuristic h = new LinearEarlyTardyHeuristic(problem, k);
+    LinearEarlyTardyHeuristic h = new LinearEarlyTardyHeuristic(problem, problem.getData(), k);
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     PartialPermutation partial = new PartialPermutation(p.length);
     for (int j = 0; j < expected.length; j++) {

--- a/src/test/java/org/cicirello/search/problems/scheduling/MinimumSlackTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/MinimumSlackTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -36,7 +36,7 @@ public class MinimumSlackTimeTests extends SchedulingHeuristicValidation {
     int[] duedates = {3, 8, 5, 2};
     double[] expected = {7, 4, 6, 11};
     FakeProblemDuedates problem = new FakeProblemDuedates(duedates, p);
-    MinimumSlackTime h = new MinimumSlackTime(problem);
+    MinimumSlackTime h = new MinimumSlackTime(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     for (int j = 0; j < duedates.length; j++) {
       assertEquals(expected[j], h.h(null, j, inc), 1E-10);
@@ -44,7 +44,7 @@ public class MinimumSlackTimeTests extends SchedulingHeuristicValidation {
 
     PartialPermutation partial = new PartialPermutation(expected.length);
     problem = new FakeProblemDuedates(duedates, p, 3);
-    h = new MinimumSlackTime(problem);
+    h = new MinimumSlackTime(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     for (int j = 0; j < duedates.length; j++) {
       assertEquals(expected[j] + 3, h.h(partial, j, inc), 1E-10);
@@ -61,7 +61,7 @@ public class MinimumSlackTimeTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new MinimumSlackTime(pr);
+              new MinimumSlackTime(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/MontagneTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/MontagneTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -43,7 +43,7 @@ public class MontagneTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All d=0
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    Montagne h = new Montagne(problem);
+    Montagne h = new Montagne(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -51,7 +51,7 @@ public class MontagneTests extends SchedulingHeuristicValidation {
     }
     // All d = pSum
     problem = new FakeProblemWeightsPTime(w, p, pSum);
-    h = new Montagne(problem);
+    h = new Montagne(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -59,7 +59,7 @@ public class MontagneTests extends SchedulingHeuristicValidation {
     }
     // All d = pSum / 2
     problem = new FakeProblemWeightsPTime(w, p, pSum / 2);
-    h = new Montagne(problem);
+    h = new Montagne(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -75,7 +75,7 @@ public class MontagneTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new Montagne(pr);
+              new Montagne(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/SchedulingHeuristicTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SchedulingHeuristicTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -34,7 +34,7 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
   public void testBaseClassMethods() {
     int[] duedates = {3, 0, 1, 7};
     FakeProblemDuedates problem = new FakeProblemDuedates(duedates);
-    EarliestDueDate h = new EarliestDueDate(problem);
+    EarliestDueDate h = new EarliestDueDate(problem, problem.getData());
     assertEquals(problem, h.getProblem());
     assertEquals(4, h.completeLength());
     for (int i = 1; i < 4; i++) {
@@ -51,7 +51,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {3, 5, 6, 10, 15};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -70,7 +71,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {10, 13, 18, 29, 44};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 7);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -89,7 +91,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {7, 5, 4, 0, -5};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 10);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -108,7 +111,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {19, 16, 11, 0, -15};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 29, 7);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -126,7 +130,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {7, 5, 4, 0, 0};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 10);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -145,7 +150,8 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] e = {19, 16, 11, 0, 0};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 29, 7);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(e.length);
     SchedulingHeuristic.IncrementalTimeCalculator inc =
         (SchedulingHeuristic.IncrementalTimeCalculator) h.createIncrementalEvaluation();
@@ -163,7 +169,7 @@ public class SchedulingHeuristicTests extends SchedulingHeuristicValidation {
     int[] p = {3, 2, 1, 4, 5};
     int[] expectedTotal = {15, 12, 10, 9, 5};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 10);
-    Montagne h = new Montagne(problem);
+    Montagne h = new Montagne(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(expectedTotal.length);
     SchedulingHeuristic.IncrementalAverageProcessingCalculator inc =
         (SchedulingHeuristic.IncrementalAverageProcessingCalculator)

--- a/src/test/java/org/cicirello/search/problems/scheduling/SchedulingHeuristicValidation.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SchedulingHeuristicValidation.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,6 +32,10 @@ public class SchedulingHeuristicValidation {
 
     private FakeProblemData data;
 
+    public FakeProblemData getData() {
+      return data;
+    }
+
     public FakeProblemDuedates(int[] d) {
       data = new FakeProblemData(d);
     }
@@ -43,11 +47,6 @@ public class SchedulingHeuristicValidation {
     public FakeProblemDuedates(int[] d, int[] p, int s) {
       data = new FakeProblemData(d, p, true);
       data.s = s;
-    }
-
-    @Override
-    public SingleMachineSchedulingProblemData getInstanceData() {
-      return data;
     }
 
     @Override
@@ -64,6 +63,10 @@ public class SchedulingHeuristicValidation {
   static class FakeProblemWeightsPTime implements SingleMachineSchedulingProblem {
 
     private FakeProblemData data;
+
+    public FakeProblemData getData() {
+      return data;
+    }
 
     public FakeProblemWeightsPTime(int[] w, int[] p) {
       data = new FakeProblemData(w, p);
@@ -90,11 +93,6 @@ public class SchedulingHeuristicValidation {
     }
 
     @Override
-    public SingleMachineSchedulingProblemData getInstanceData() {
-      return data;
-    }
-
-    @Override
     public int cost(Permutation p) {
       return 10;
     }
@@ -109,13 +107,12 @@ public class SchedulingHeuristicValidation {
 
     private FakeEarlyTardyProblemData data;
 
-    public FakeEarlyTardyProblem(int[] p, int[] we, int[] wt, int[] d) {
-      data = new FakeEarlyTardyProblemData(p, we, wt, d);
+    public FakeEarlyTardyProblemData getData() {
+      return data;
     }
 
-    @Override
-    public SingleMachineSchedulingProblemData getInstanceData() {
-      return data;
+    public FakeEarlyTardyProblem(int[] p, int[] we, int[] wt, int[] d) {
+      data = new FakeEarlyTardyProblemData(p, we, wt, d);
     }
 
     @Override

--- a/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecomputeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimePrecomputeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -38,7 +38,7 @@ public class ShortestProcessingPlusSetupTimePrecomputeTests extends SchedulingHe
     PartialPermutation partial = new PartialPermutation(expected.length);
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
     ShortestProcessingPlusSetupTimePrecompute h =
-        new ShortestProcessingPlusSetupTimePrecompute(problem);
+        new ShortestProcessingPlusSetupTimePrecompute(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);
     }
@@ -49,7 +49,7 @@ public class ShortestProcessingPlusSetupTimePrecomputeTests extends SchedulingHe
 
     int[] ps = {0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new ShortestProcessingPlusSetupTimePrecompute(problem);
+    h = new ShortestProcessingPlusSetupTimePrecompute(problem, problem.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingPlusSetupTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -37,7 +37,8 @@ public class ShortestProcessingPlusSetupTimeTests extends SchedulingHeuristicVal
     double[] expected = {1, 0.5, 0.25, 0.125, 1, 0.5, 0.25, 0.125, 1, 0.5, 0.25, 0.125, e};
     PartialPermutation partial = new PartialPermutation(expected.length);
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
-    ShortestProcessingPlusSetupTime h = new ShortestProcessingPlusSetupTime(problem);
+    ShortestProcessingPlusSetupTime h =
+        new ShortestProcessingPlusSetupTime(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);
     }
@@ -48,7 +49,7 @@ public class ShortestProcessingPlusSetupTimeTests extends SchedulingHeuristicVal
 
     int[] ps = {0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new ShortestProcessingPlusSetupTime(problem);
+    h = new ShortestProcessingPlusSetupTime(problem, problem.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/ShortestProcessingTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -35,7 +35,7 @@ public class ShortestProcessingTimeTests extends SchedulingHeuristicValidation {
     int[] p = {1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8, highP};
     double[] expected = {1, 0.5, 0.25, 0.125, 1, 0.5, 0.25, 0.125, 1, 0.5, 0.25, 0.125, e};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
-    ShortestProcessingTime h = new ShortestProcessingTime(problem);
+    ShortestProcessingTime h = new ShortestProcessingTime(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(null, j, null), 1E-10);
     }

--- a/src/test/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetupTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SmallestNormalizedSetupTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -44,7 +44,7 @@ public class SmallestNormalizedSetupTests extends SchedulingHeuristicValidation 
     int[] p = {2, 5, 9, 2, 10};
     double[] expected = {1, 0.5, 0.25};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, s);
-    SmallestNormalizedSetup h = new SmallestNormalizedSetup(problem);
+    SmallestNormalizedSetup h = new SmallestNormalizedSetup(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(p.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10, "j:" + j);
@@ -60,7 +60,7 @@ public class SmallestNormalizedSetupTests extends SchedulingHeuristicValidation 
     assertEquals(0.5, h.h(partial, 0, null), 1E-10);
 
     FakeProblemWeightsPTime problemNoSetups = new FakeProblemWeightsPTime(w, p, 0);
-    h = new SmallestNormalizedSetup(problemNoSetups);
+    h = new SmallestNormalizedSetup(problemNoSetups, problemNoSetups.getData());
     partial = new PartialPermutation(p.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(1.0, h.h(partial, j, null), 1E-10);
@@ -69,7 +69,7 @@ public class SmallestNormalizedSetupTests extends SchedulingHeuristicValidation 
     final int N = highS / 2;
 
     FakeProblemSmallestNormSetup pr = new FakeProblemSmallestNormSetup(N);
-    h = new SmallestNormalizedSetup(pr);
+    h = new SmallestNormalizedSetup(pr, pr.getData());
     partial = new PartialPermutation(N);
     assertEquals(e, h.h(partial, 2, null), 1E-10);
   }
@@ -125,7 +125,7 @@ public class SmallestNormalizedSetupTests extends SchedulingHeuristicValidation 
       return 0;
     }
 
-    public SingleMachineSchedulingProblemData getInstanceData() {
+    public FakeProblemSmallestNormSetupData getData() {
       return new FakeProblemSmallestNormSetupData(N);
     }
   }

--- a/src/test/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecomputeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SmallestSetupPrecomputeTests.java
@@ -44,7 +44,7 @@ public class SmallestSetupPrecomputeTests extends SchedulingHeuristicValidation 
     int[] p = {2, 5, 9, 2, 10};
     double[] expected = {1, 0.5, 0.25, 0.125, 0.0625};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, s);
-    SmallestSetupPrecompute h = new SmallestSetupPrecompute(problem);
+    SmallestSetupPrecompute h = new SmallestSetupPrecompute(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);
@@ -63,7 +63,7 @@ public class SmallestSetupPrecomputeTests extends SchedulingHeuristicValidation 
       Arrays.fill(s[i], highS);
     }
     problem = new FakeProblemWeightsPTime(w, p, 0, s);
-    h = new SmallestSetupPrecompute(problem);
+    h = new SmallestSetupPrecompute(problem, problem.getData());
     for (int i = 0; i < s.length; i++) {
       partial = new PartialPermutation(expected.length);
       assertEquals(e, h.h(partial, i, null), 1E-10);
@@ -77,7 +77,7 @@ public class SmallestSetupPrecomputeTests extends SchedulingHeuristicValidation 
     }
 
     FakeProblemWeightsPTime problemNoSetups = new FakeProblemWeightsPTime(w, p, 0);
-    h = new SmallestSetupPrecompute(problemNoSetups);
+    h = new SmallestSetupPrecompute(problemNoSetups, problemNoSetups.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < p.length; j++) {
       assertEquals(1.0, h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/SmallestSetupTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SmallestSetupTests.java
@@ -43,7 +43,7 @@ public class SmallestSetupTests extends SchedulingHeuristicValidation {
     int[] p = {2, 5, 9, 2, 10};
     double[] expected = {1, 0.5, 0.25, 0.125, 0.0625};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, s);
-    SmallestSetup h = new SmallestSetup(problem);
+    SmallestSetup h = new SmallestSetup(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);
@@ -59,7 +59,7 @@ public class SmallestSetupTests extends SchedulingHeuristicValidation {
     }
 
     FakeProblemWeightsPTime problemNoSetups = new FakeProblemWeightsPTime(w, p, 0);
-    h = new SmallestSetup(problemNoSetups);
+    h = new SmallestSetup(problemNoSetups, problemNoSetups.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < p.length; j++) {
       assertEquals(1.0, h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetupTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/SmallestTwoJobSetupTests.java
@@ -43,7 +43,7 @@ public class SmallestTwoJobSetupTests extends SchedulingHeuristicValidation {
     int[] p = {2, 5, 9, 2, 10};
     double[] expected = {1, 0.5, 0.25, 0.125, 0.0625};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, s);
-    SmallestTwoJobSetup h = new SmallestTwoJobSetup(problem);
+    SmallestTwoJobSetup h = new SmallestTwoJobSetup(problem, problem.getData());
     PartialPermutation partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10, "scheduled first");
@@ -60,7 +60,7 @@ public class SmallestTwoJobSetupTests extends SchedulingHeuristicValidation {
     int k = partial.getExtension(0);
     assertEquals(1.0 / (1.0 + s[partial.getLast()][k]), h.h(partial, k, null), 1E-10);
     FakeProblemWeightsPTime problemNoSetups = new FakeProblemWeightsPTime(w, p, 0);
-    h = new SmallestTwoJobSetup(problemNoSetups);
+    h = new SmallestTwoJobSetup(problemNoSetups, problemNoSetups.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < p.length; j++) {
       assertEquals(1.0, h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjustedTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeSetupAdjustedTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -46,7 +46,8 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedCostOverTimeSetupAdjusted h = new WeightedCostOverTimeSetupAdjusted(problem);
+    WeightedCostOverTimeSetupAdjusted h =
+        new WeightedCostOverTimeSetupAdjusted(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -54,7 +55,7 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCostOverTimeSetupAdjusted(problem);
+    h = new WeightedCostOverTimeSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -66,7 +67,7 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCostOverTimeSetupAdjusted(problem, 4);
+    h = new WeightedCostOverTimeSetupAdjusted(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -84,12 +85,14 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedCostOverTimeSetupAdjusted(pr);
+              new WeightedCostOverTimeSetupAdjusted(pr, pr.getData());
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new WeightedCostOverTimeSetupAdjusted(new FakeProblemWeightsPTime(w, p, 0), 0));
+            () ->
+                new WeightedCostOverTimeSetupAdjusted(
+                    new FakeProblemWeightsPTime(w, p, 0), new FakeProblemData(w, p, 0), 0));
   }
 
   @Test
@@ -108,7 +111,8 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0, 1);
-    WeightedCostOverTimeSetupAdjusted h = new WeightedCostOverTimeSetupAdjusted(problem);
+    WeightedCostOverTimeSetupAdjusted h =
+        new WeightedCostOverTimeSetupAdjusted(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -116,7 +120,7 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20, 1);
-    h = new WeightedCostOverTimeSetupAdjusted(problem);
+    h = new WeightedCostOverTimeSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -128,7 +132,7 @@ public class WeightedCostOverTimeSetupAdjustedTests extends SchedulingHeuristicV
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20, 1);
-    h = new WeightedCostOverTimeSetupAdjusted(problem, 4);
+    h = new WeightedCostOverTimeSetupAdjusted(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedCostOverTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -46,7 +46,7 @@ public class WeightedCostOverTimeTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedCostOverTime h = new WeightedCostOverTime(problem);
+    WeightedCostOverTime h = new WeightedCostOverTime(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -54,7 +54,7 @@ public class WeightedCostOverTimeTests extends SchedulingHeuristicValidation {
     }
     // d=20, k default of 2
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCostOverTime(problem);
+    h = new WeightedCostOverTime(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -66,7 +66,7 @@ public class WeightedCostOverTimeTests extends SchedulingHeuristicValidation {
     }
     // d=20, k=4
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCostOverTime(problem, 4);
+    h = new WeightedCostOverTime(problem, problem.getData(), 4);
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -84,11 +84,13 @@ public class WeightedCostOverTimeTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedCostOverTime(pr);
+              new WeightedCostOverTime(pr, pr.getData());
             });
     thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new WeightedCostOverTime(new FakeProblemWeightsPTime(w, p, 0), 0));
+            () ->
+                new WeightedCostOverTime(
+                    new FakeProblemWeightsPTime(w, p, 0), new FakeProblemData(w, p, 0), 0));
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjustedTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioSetupAdjustedTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -43,7 +43,8 @@ public class WeightedCriticalRatioSetupAdjustedTests extends SchedulingHeuristic
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedCriticalRatioSetupAdjusted h = new WeightedCriticalRatioSetupAdjusted(problem);
+    WeightedCriticalRatioSetupAdjusted h =
+        new WeightedCriticalRatioSetupAdjusted(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -51,7 +52,7 @@ public class WeightedCriticalRatioSetupAdjustedTests extends SchedulingHeuristic
     }
     // All on time tests
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCriticalRatioSetupAdjusted(problem);
+    h = new WeightedCriticalRatioSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -63,14 +64,14 @@ public class WeightedCriticalRatioSetupAdjustedTests extends SchedulingHeuristic
     // Repeat with setups
     int[] ps = {0, 0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new WeightedCriticalRatioSetupAdjusted(problem);
+    h = new WeightedCriticalRatioSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
       assertEquals(expected0[j], h.h(partial, j, inc), 1E-10, "negativeSlack, j:" + j);
     }
     problem = new FakeProblemWeightsPTime(w, ps, 20, 1);
-    h = new WeightedCriticalRatioSetupAdjusted(problem);
+    h = new WeightedCriticalRatioSetupAdjusted(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -87,7 +88,7 @@ public class WeightedCriticalRatioSetupAdjustedTests extends SchedulingHeuristic
     // MIN_H case
     problem =
         new FakeProblemWeightsPTime(new int[] {1, 1}, new int[] {1, 1}, (int) Math.ceil(2 / e), 1);
-    h = new WeightedCriticalRatioSetupAdjusted(problem);
+    h = new WeightedCriticalRatioSetupAdjusted(problem, problem.getData());
     partial = new PartialPermutation(2);
     inc = h.createIncrementalEvaluation();
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -100,7 +101,7 @@ public class WeightedCriticalRatioSetupAdjustedTests extends SchedulingHeuristic
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedCriticalRatioSetupAdjusted(pr);
+              new WeightedCriticalRatioSetupAdjusted(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedCriticalRatioTests.java
@@ -43,7 +43,7 @@ public class WeightedCriticalRatioTests extends SchedulingHeuristicValidation {
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedCriticalRatio h = new WeightedCriticalRatio(problem);
+    WeightedCriticalRatio h = new WeightedCriticalRatio(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -51,7 +51,7 @@ public class WeightedCriticalRatioTests extends SchedulingHeuristicValidation {
     }
     // All on time tests
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedCriticalRatio(problem);
+    h = new WeightedCriticalRatio(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected0.length; j++) {
@@ -63,7 +63,7 @@ public class WeightedCriticalRatioTests extends SchedulingHeuristicValidation {
     // MIN_H case
     problem =
         new FakeProblemWeightsPTime(new int[] {1, 1}, new int[] {1, 1}, (int) Math.ceil(2 / e));
-    h = new WeightedCriticalRatio(problem);
+    h = new WeightedCriticalRatio(problem, problem.getData());
     partial = new PartialPermutation(2);
     inc = h.createIncrementalEvaluation();
     assertEquals(e, h.h(partial, 0, inc), 1E-10);
@@ -76,7 +76,7 @@ public class WeightedCriticalRatioTests extends SchedulingHeuristicValidation {
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedCriticalRatio(pr);
+              new WeightedCriticalRatio(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedLongestProcessingTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -42,7 +42,7 @@ public class WeightedLongestProcessingTimeTests extends SchedulingHeuristicValid
     int[] d = {2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5};
 
     FakeEarlyTardyProblem problem = new FakeEarlyTardyProblem(p, we, wt, d);
-    WeightedLongestProcessingTime h = new WeightedLongestProcessingTime(problem);
+    WeightedLongestProcessingTime h = new WeightedLongestProcessingTime(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(null, j, null), 1E-10, "j:" + j);
     }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnlyTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeLateOnlyTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -43,7 +43,7 @@ public class WeightedShortestProcessingPlusSetupTimeLateOnlyTests
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
     WeightedShortestProcessingPlusSetupTimeLateOnly h =
-        new WeightedShortestProcessingPlusSetupTimeLateOnly(problem);
+        new WeightedShortestProcessingPlusSetupTimeLateOnly(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
@@ -51,7 +51,7 @@ public class WeightedShortestProcessingPlusSetupTimeLateOnlyTests
     }
     // All on time tests
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem);
+    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
@@ -60,14 +60,14 @@ public class WeightedShortestProcessingPlusSetupTimeLateOnlyTests
     // Repeat with setups
     int[] ps = {0, 0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem);
+    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, inc), 1E-10, "j:" + j);
     }
     problem = new FakeProblemWeightsPTime(w, ps, 20, 1);
-    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem);
+    h = new WeightedShortestProcessingPlusSetupTimeLateOnly(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
@@ -81,7 +81,7 @@ public class WeightedShortestProcessingPlusSetupTimeLateOnlyTests
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedShortestProcessingPlusSetupTimeLateOnly(pr);
+              new WeightedShortestProcessingPlusSetupTimeLateOnly(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecomputeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimePrecomputeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -39,7 +39,7 @@ public class WeightedShortestProcessingPlusSetupTimePrecomputeTests
     PartialPermutation partial = new PartialPermutation(expected.length);
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
     WeightedShortestProcessingPlusSetupTimePrecompute h =
-        new WeightedShortestProcessingPlusSetupTimePrecompute(problem);
+        new WeightedShortestProcessingPlusSetupTimePrecompute(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10, "j:" + j);
     }
@@ -50,7 +50,7 @@ public class WeightedShortestProcessingPlusSetupTimePrecomputeTests
 
     int[] ps = {0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new WeightedShortestProcessingPlusSetupTimePrecompute(problem);
+    h = new WeightedShortestProcessingPlusSetupTimePrecompute(problem, problem.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingPlusSetupTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -38,7 +38,7 @@ public class WeightedShortestProcessingPlusSetupTimeTests extends SchedulingHeur
     PartialPermutation partial = new PartialPermutation(expected.length);
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
     WeightedShortestProcessingPlusSetupTime h =
-        new WeightedShortestProcessingPlusSetupTime(problem);
+        new WeightedShortestProcessingPlusSetupTime(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);
     }
@@ -49,7 +49,7 @@ public class WeightedShortestProcessingPlusSetupTimeTests extends SchedulingHeur
 
     int[] ps = {0, 1, 3, 7, 0, 1, 3, 7, 0, 1, 3, 7, highP - 1};
     problem = new FakeProblemWeightsPTime(w, ps, 0, 1);
-    h = new WeightedShortestProcessingPlusSetupTime(problem);
+    h = new WeightedShortestProcessingPlusSetupTime(problem, problem.getData());
     partial = new PartialPermutation(expected.length);
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(partial, j, null), 1E-10);

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnlyTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeLateOnlyTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -41,7 +41,8 @@ public class WeightedShortestProcessingTimeLateOnlyTests extends SchedulingHeuri
     // Doesn't really matter: partial.extend(0);
     // All late tests
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p, 0);
-    WeightedShortestProcessingTimeLateOnly h = new WeightedShortestProcessingTimeLateOnly(problem);
+    WeightedShortestProcessingTimeLateOnly h =
+        new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     IncrementalEvaluation<Permutation> inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
@@ -49,7 +50,7 @@ public class WeightedShortestProcessingTimeLateOnlyTests extends SchedulingHeuri
     }
     // All on time tests
     problem = new FakeProblemWeightsPTime(w, p, 20);
-    h = new WeightedShortestProcessingTimeLateOnly(problem);
+    h = new WeightedShortestProcessingTimeLateOnly(problem, problem.getData());
     inc = h.createIncrementalEvaluation();
     inc.extend(partial, 0);
     for (int j = 1; j < expected.length; j++) {
@@ -63,7 +64,7 @@ public class WeightedShortestProcessingTimeLateOnlyTests extends SchedulingHeuri
               int[] p2 = {1, 1};
               int[] w2 = {1, 1};
               FakeProblemWeightsPTime pr = new FakeProblemWeightsPTime(p2, w2);
-              new WeightedShortestProcessingTimeLateOnly(pr);
+              new WeightedShortestProcessingTimeLateOnly(pr, pr.getData());
             });
   }
 }

--- a/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeTests.java
+++ b/src/test/java/org/cicirello/search/problems/scheduling/WeightedShortestProcessingTimeTests.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -35,7 +35,8 @@ public class WeightedShortestProcessingTimeTests extends SchedulingHeuristicVali
     int[] p = {1, 2, 4, 8, 1, 2, 4, 8, 1, 2, 4, 8, highP};
     double[] expected = {1, 0.5, 0.25, 0.125, e, e, e, e, 2, 1, 0.5, 0.25, e};
     FakeProblemWeightsPTime problem = new FakeProblemWeightsPTime(w, p);
-    WeightedShortestProcessingTime h = new WeightedShortestProcessingTime(problem);
+    WeightedShortestProcessingTime h =
+        new WeightedShortestProcessingTime(problem, problem.getData());
     for (int j = 0; j < expected.length; j++) {
       assertEquals(expected[j], h.h(null, j, null), 1E-10);
     }


### PR DESCRIPTION
## Summary
Refactored all the constructive scheduling heuristics and single machine scheduling problems:
* To remove the getInstanceData() method from the SingleMachineSchedulingProblem interface, and
* To require passing an instance of SingleMachineSchedulingProblemData, in addition to the SingleMachineSchedulingProblem, to the constructive scheduling heuristics.

## Closing Issues
Closes #857 

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
