### PR TITLE
Moved Generation instance from AbstractEvolutionaryAlgorithm class into BasePopulation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-07-25
+## [Unreleased] - 2026-07-27
 
 ### Added
 
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Minor code improvements to implementations of equals methods in a few classes
+* Refactored: moved Generation instance from AbstractEvolutionaryAlgorithm class into BasePopulation class
 
 ### Dependencies
 

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -141,7 +141,7 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
 
   private void internalOptimize(int numGenerations) {
     for (int i = 0; i < numGenerations && !pop.evolutionIsPaused(); i++) {
-      numFitnessEvals = numFitnessEvals + pop.generation(generation);
+      numFitnessEvals = numFitnessEvals + pop.generation();
     }
   }
 }

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -141,9 +141,7 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
 
   private void internalOptimize(int numGenerations) {
     for (int i = 0; i < numGenerations && !pop.evolutionIsPaused(); i++) {
-      pop.select();
-      numFitnessEvals = numFitnessEvals + generation.apply(pop);
-      pop.replace();
+      numFitnessEvals = numFitnessEvals + pop.generation(generation);
     }
   }
 }

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -38,17 +38,15 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
 
   private final Population<T> pop;
   private final Problem<T> problem;
-  private final Generation<T> generation;
   private long numFitnessEvals;
 
   /*
    * Internal constructor for use by subclasses in same package.
    * Initializes the base class.
    */
-  AbstractEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem, Generation<T> generation) {
+  AbstractEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
     this.pop = pop;
     this.problem = problem;
-    this.generation = generation;
   }
 
   /*
@@ -58,7 +56,6 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
   AbstractEvolutionaryAlgorithm(AbstractEvolutionaryAlgorithm<T> other) {
     // Must be split
     pop = other.pop.split();
-    generation = other.generation.split();
 
     // Threadsafe so just copy reference or values
     problem = other.problem;

--- a/src/main/java/org/cicirello/search/evo/AbstractPopulation.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractPopulation.java
@@ -63,7 +63,7 @@ abstract class AbstractPopulation<T extends Copyable<T>> implements Population<T
   }
 
   @Override
-  public boolean evolutionIsPaused() {
+  public final boolean evolutionIsPaused() {
     return tracker.didFindBest() || tracker.isStopped();
   }
 

--- a/src/main/java/org/cicirello/search/evo/AdaptiveEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AdaptiveEvolutionaryAlgorithm.java
@@ -119,9 +119,7 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
             eliteCount,
             2,
             new AdaptiveGeneration<T>(mutation, crossover)),
-        f.getProblem(),
-        mutation,
-        crossover);
+        f.getProblem());
   }
 
   /**
@@ -161,9 +159,7 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
             eliteCount,
             2,
             new AdaptiveGeneration<T>(mutation, crossover)),
-        f.getProblem(),
-        mutation,
-        crossover);
+        f.getProblem());
   }
 
   /**
@@ -203,9 +199,7 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
             tracker,
             2,
             new AdaptiveGeneration<T>(mutation, crossover)),
-        f.getProblem(),
-        mutation,
-        crossover);
+        f.getProblem());
   }
 
   /**
@@ -245,9 +239,7 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
             tracker,
             2,
             new AdaptiveGeneration<T>(mutation, crossover)),
-        f.getProblem(),
-        mutation,
-        crossover);
+        f.getProblem());
   }
 
   /**
@@ -467,12 +459,8 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
   /*
    * Internal helper constructor
    */
-  private AdaptiveEvolutionaryAlgorithm(
-      Population<T> pop,
-      Problem<T> problem,
-      MutationOperator<T> mutation,
-      CrossoverOperator<T> crossover) {
-    super(pop, problem, new AdaptiveGeneration<T>(mutation, crossover));
+  private AdaptiveEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
+    super(pop, problem);
   }
 
   /*

--- a/src/main/java/org/cicirello/search/evo/AdaptiveEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AdaptiveEvolutionaryAlgorithm.java
@@ -111,7 +111,14 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.DoubleFitness<T>(
-            n, initializer, f, selection, tracker, eliteCount, 2),
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            2,
+            new AdaptiveGeneration<T>(mutation, crossover)),
         f.getProblem(),
         mutation,
         crossover);
@@ -146,7 +153,14 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.IntegerFitness<T>(
-            n, initializer, f, selection, tracker, eliteCount, 2),
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            2,
+            new AdaptiveGeneration<T>(mutation, crossover)),
         f.getProblem(),
         mutation,
         crossover);
@@ -181,7 +195,14 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.DoubleFitness<T>(
-            n, initializer, f, selection, replacement, tracker, 2),
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            2,
+            new AdaptiveGeneration<T>(mutation, crossover)),
         f.getProblem(),
         mutation,
         crossover);
@@ -216,7 +237,14 @@ public final class AdaptiveEvolutionaryAlgorithm<T extends Copyable<T>>
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.IntegerFitness<T>(
-            n, initializer, f, selection, replacement, tracker, 2),
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            2,
+            new AdaptiveGeneration<T>(mutation, crossover)),
         f.getProblem(),
         mutation,
         crossover);

--- a/src/main/java/org/cicirello/search/evo/AdaptiveMutationOnlyEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AdaptiveMutationOnlyEvolutionaryAlgorithm.java
@@ -111,8 +111,7 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
             eliteCount,
             1,
             new AdaptiveMutationOnlyGeneration<T>(mutation)),
-        f.getProblem(),
-        mutation);
+        f.getProblem());
   }
 
   /**
@@ -150,8 +149,7 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
             eliteCount,
             1,
             new AdaptiveMutationOnlyGeneration<T>(mutation)),
-        f.getProblem(),
-        mutation);
+        f.getProblem());
   }
 
   /**
@@ -189,8 +187,7 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
             tracker,
             1,
             new AdaptiveMutationOnlyGeneration<T>(mutation)),
-        f.getProblem(),
-        mutation);
+        f.getProblem());
   }
 
   /**
@@ -228,8 +225,7 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
             tracker,
             1,
             new AdaptiveMutationOnlyGeneration<T>(mutation)),
-        f.getProblem(),
-        mutation);
+        f.getProblem());
   }
 
   /**
@@ -429,9 +425,8 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
   /*
    * Internal helper constructor
    */
-  private AdaptiveMutationOnlyEvolutionaryAlgorithm(
-      Population<T> pop, Problem<T> problem, MutationOperator<T> mutation) {
-    super(pop, problem, new AdaptiveMutationOnlyGeneration<T>(mutation));
+  private AdaptiveMutationOnlyEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
+    super(pop, problem);
   }
 
   /*

--- a/src/main/java/org/cicirello/search/evo/AdaptiveMutationOnlyEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AdaptiveMutationOnlyEvolutionaryAlgorithm.java
@@ -103,7 +103,14 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.DoubleFitness<T>(
-            n, initializer, f, selection, tracker, eliteCount, 1),
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            1,
+            new AdaptiveMutationOnlyGeneration<T>(mutation)),
         f.getProblem(),
         mutation);
   }
@@ -135,7 +142,14 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.IntegerFitness<T>(
-            n, initializer, f, selection, tracker, eliteCount, 1),
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            1,
+            new AdaptiveMutationOnlyGeneration<T>(mutation)),
         f.getProblem(),
         mutation);
   }
@@ -167,7 +181,14 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.DoubleFitness<T>(
-            n, initializer, f, selection, replacement, tracker, 1),
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            1,
+            new AdaptiveMutationOnlyGeneration<T>(mutation)),
         f.getProblem(),
         mutation);
   }
@@ -199,7 +220,14 @@ public final class AdaptiveMutationOnlyEvolutionaryAlgorithm<T extends Copyable<
       ProgressTracker<T> tracker) {
     this(
         new EvolvableParametersPopulation.IntegerFitness<T>(
-            n, initializer, f, selection, replacement, tracker, 1),
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            1,
+            new AdaptiveMutationOnlyGeneration<T>(mutation)),
         f.getProblem(),
         mutation);
   }

--- a/src/main/java/org/cicirello/search/evo/BasePopulation.java
+++ b/src/main/java/org/cicirello/search/evo/BasePopulation.java
@@ -251,7 +251,7 @@ abstract class BasePopulation {
     }
 
     @Override
-    public final int generation(Generation<T> generation) {
+    public final int generation() {
       select();
       int evaluations = generation.apply(this);
       replace();
@@ -549,7 +549,7 @@ abstract class BasePopulation {
     }
 
     @Override
-    public final int generation(Generation<T> generation) {
+    public final int generation() {
       select();
       int evaluations = generation.apply(this);
       replace();

--- a/src/main/java/org/cicirello/search/evo/BasePopulation.java
+++ b/src/main/java/org/cicirello/search/evo/BasePopulation.java
@@ -73,6 +73,7 @@ abstract class BasePopulation {
     private final ReplacementStrategy<T> replacement;
     private final ReplacementTracker r;
     private final PopulationMemberCreator<T> creator;
+    private final Generation<T> generation;
 
     private final FitnessFunction.Double<T> f;
     private final int MU;
@@ -99,7 +100,8 @@ abstract class BasePopulation {
         FitnessFunction.Double<T> f,
         SelectionOperator selection,
         ProgressTracker<T> tracker,
-        int numElite) {
+        int numElite,
+        Generation<T> generation) {
       this(
           validateN(n),
           Objects.requireNonNull(initializer),
@@ -110,7 +112,8 @@ abstract class BasePopulation {
           validateElite(numElite, n),
           numElite > 0
               ? new GenerationalElitistReplacement<T>(numElite)
-              : new GenerationalReplacement<T>());
+              : new GenerationalReplacement<T>(),
+          Objects.requireNonNull(generation));
     }
 
     /**
@@ -130,7 +133,8 @@ abstract class BasePopulation {
         FitnessFunction.Double<T> f,
         SelectionOperator selection,
         ReplacementStrategy<T> replacement,
-        ProgressTracker<T> tracker) {
+        ProgressTracker<T> tracker,
+        Generation<T> generation) {
       this(
           validateN(n),
           Objects.requireNonNull(initializer),
@@ -139,7 +143,8 @@ abstract class BasePopulation {
           Objects.requireNonNull(tracker),
           (candidate, fitness) -> new PopulationMember.DoubleFitness<T>(candidate, fitness),
           0,
-          Objects.requireNonNull(replacement));
+          Objects.requireNonNull(replacement),
+          Objects.requireNonNull(generation));
     }
 
     /*
@@ -153,11 +158,13 @@ abstract class BasePopulation {
         ProgressTracker<T> tracker,
         PopulationMemberCreator<T> creator,
         int numElite,
-        ReplacementStrategy<T> replacement) {
+        ReplacementStrategy<T> replacement,
+        Generation<T> generation) {
       super(tracker);
       this.initializer = initializer;
       this.selection = selection;
       this.replacement = replacement;
+      this.generation = generation;
 
       this.f = f;
       MU = n;
@@ -187,6 +194,7 @@ abstract class BasePopulation {
       selection = other.selection.split();
       replacement = other.replacement.split();
       creator = other.creator.split();
+      generation = other.generation.split();
 
       // initialize these fresh: not threadsafe or otherwise needs its own
       r = new ReplacementTracker(MU, LAMBDA);
@@ -363,6 +371,7 @@ abstract class BasePopulation {
     private final ReplacementStrategy<T> replacement;
     private final ReplacementTracker r;
     private final PopulationMemberCreator<T> creator;
+    private final Generation<T> generation;
 
     private final FitnessFunction.Integer<T> f;
     private final int MU;
@@ -389,7 +398,8 @@ abstract class BasePopulation {
         FitnessFunction.Integer<T> f,
         SelectionOperator selection,
         ProgressTracker<T> tracker,
-        int numElite) {
+        int numElite,
+        Generation<T> generation) {
       this(
           validateN(n),
           Objects.requireNonNull(initializer),
@@ -400,7 +410,8 @@ abstract class BasePopulation {
           validateElite(numElite, n),
           numElite > 0
               ? new GenerationalElitistReplacement<T>(numElite)
-              : new GenerationalReplacement<T>());
+              : new GenerationalReplacement<T>(),
+          Objects.requireNonNull(generation));
     }
 
     /**
@@ -420,7 +431,8 @@ abstract class BasePopulation {
         FitnessFunction.Integer<T> f,
         SelectionOperator selection,
         ReplacementStrategy<T> replacement,
-        ProgressTracker<T> tracker) {
+        ProgressTracker<T> tracker,
+        Generation<T> generation) {
       this(
           validateN(n),
           Objects.requireNonNull(initializer),
@@ -429,7 +441,8 @@ abstract class BasePopulation {
           Objects.requireNonNull(tracker),
           (candidate, fitness) -> new PopulationMember.IntegerFitness<T>(candidate, fitness),
           0,
-          Objects.requireNonNull(replacement));
+          Objects.requireNonNull(replacement),
+          Objects.requireNonNull(generation));
     }
 
     /*
@@ -443,11 +456,13 @@ abstract class BasePopulation {
         ProgressTracker<T> tracker,
         PopulationMemberCreator<T> creator,
         int numElite,
-        ReplacementStrategy<T> replacement) {
+        ReplacementStrategy<T> replacement,
+        Generation<T> generation) {
       super(tracker);
       this.initializer = initializer;
       this.selection = selection;
       this.replacement = replacement;
+      this.generation = generation;
 
       this.f = f;
       MU = n;
@@ -477,6 +492,7 @@ abstract class BasePopulation {
       selection = other.selection.split();
       replacement = other.replacement.split();
       creator = other.creator.split();
+      generation = other.generation.split();
 
       // initialize these fresh: not threadsafe or otherwise needs its own
       r = new ReplacementTracker(MU, LAMBDA);

--- a/src/main/java/org/cicirello/search/evo/BasePopulation.java
+++ b/src/main/java/org/cicirello/search/evo/BasePopulation.java
@@ -250,16 +250,14 @@ abstract class BasePopulation {
       return evaluations;
     }
 
-    @Override
-    public final void select() {
+    final void select() {
       selection.select(pop, selected);
       for (int j : selected) {
         nextPop.add(pop.get(j).copy());
       }
     }
 
-    @Override
-    public final void replace() {
+    final void replace() {
       replacement.replace(pop, nextPop, r, MU);
       if (r.includesParents()) {
         ArrayList<PopulationMember.DoubleFitness<T>> keep =
@@ -542,16 +540,14 @@ abstract class BasePopulation {
       return evaluations;
     }
 
-    @Override
-    public final void select() {
+    final void select() {
       selection.select(pop, selected);
       for (int j : selected) {
         nextPop.add(pop.get(j).copy());
       }
     }
 
-    @Override
-    public final void replace() {
+    final void replace() {
       replacement.replace(pop, nextPop, r, MU);
       if (r.includesParents()) {
         ArrayList<PopulationMember.IntegerFitness<T>> keep =

--- a/src/main/java/org/cicirello/search/evo/BasePopulation.java
+++ b/src/main/java/org/cicirello/search/evo/BasePopulation.java
@@ -243,6 +243,14 @@ abstract class BasePopulation {
     }
 
     @Override
+    public final int generation(Generation<T> generation) {
+      select();
+      int evaluations = generation.apply(this);
+      replace();
+      return evaluations;
+    }
+
+    @Override
     public final void select() {
       selection.select(pop, selected);
       for (int j : selected) {
@@ -524,6 +532,14 @@ abstract class BasePopulation {
         bestFitness = fit;
         setMostFit(f.getProblem().getSolutionCostPair(nextPop.candidate(i).copy()));
       }
+    }
+
+    @Override
+    public final int generation(Generation<T> generation) {
+      select();
+      int evaluations = generation.apply(this);
+      replace();
+      return evaluations;
     }
 
     @Override

--- a/src/main/java/org/cicirello/search/evo/EvolvableParametersPopulation.java
+++ b/src/main/java/org/cicirello/search/evo/EvolvableParametersPopulation.java
@@ -68,7 +68,8 @@ abstract class EvolvableParametersPopulation {
         SelectionOperator selection,
         ProgressTracker<T> tracker,
         int numElite,
-        int numParams) {
+        int numParams,
+        Generation<T> generation) {
       super(
           BasePopulation.validateN(n),
           Objects.requireNonNull(initializer),
@@ -79,7 +80,8 @@ abstract class EvolvableParametersPopulation {
           BasePopulation.validateElite(numElite, n),
           numElite > 0
               ? new GenerationalElitistReplacement<T>(numElite)
-              : new GenerationalReplacement<T>());
+              : new GenerationalReplacement<T>(),
+          Objects.requireNonNull(generation));
     }
 
     /**
@@ -101,7 +103,8 @@ abstract class EvolvableParametersPopulation {
         SelectionOperator selection,
         ReplacementStrategy<T> replacement,
         ProgressTracker<T> tracker,
-        int numParams) {
+        int numParams,
+        Generation<T> generation) {
       super(
           BasePopulation.validateN(n),
           Objects.requireNonNull(initializer),
@@ -110,7 +113,8 @@ abstract class EvolvableParametersPopulation {
           Objects.requireNonNull(tracker),
           new EvolvableParametersPopulationMemberCreator<T>(numParams),
           0,
-          Objects.requireNonNull(replacement));
+          Objects.requireNonNull(replacement),
+          Objects.requireNonNull(generation));
     }
 
     /*
@@ -184,7 +188,8 @@ abstract class EvolvableParametersPopulation {
         SelectionOperator selection,
         ProgressTracker<T> tracker,
         int numElite,
-        int numParams) {
+        int numParams,
+        Generation<T> generation) {
       super(
           BasePopulation.validateN(n),
           Objects.requireNonNull(initializer),
@@ -195,7 +200,8 @@ abstract class EvolvableParametersPopulation {
           BasePopulation.validateElite(numElite, n),
           numElite > 0
               ? new GenerationalElitistReplacement<T>(numElite)
-              : new GenerationalReplacement<T>());
+              : new GenerationalReplacement<T>(),
+          Objects.requireNonNull(generation));
     }
 
     /**
@@ -217,7 +223,8 @@ abstract class EvolvableParametersPopulation {
         SelectionOperator selection,
         ReplacementStrategy<T> replacement,
         ProgressTracker<T> tracker,
-        int numParams) {
+        int numParams,
+        Generation<T> generation) {
       super(
           BasePopulation.validateN(n),
           Objects.requireNonNull(initializer),
@@ -226,7 +233,8 @@ abstract class EvolvableParametersPopulation {
           Objects.requireNonNull(tracker),
           new EvolvableParametersPopulationMemberCreator<T>(numParams),
           0,
-          Objects.requireNonNull(replacement));
+          Objects.requireNonNull(replacement),
+          Objects.requireNonNull(generation));
     }
 
     /*

--- a/src/main/java/org/cicirello/search/evo/GenerationalDisjointOperatorsEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalDisjointOperatorsEvolutionaryAlgorithm.java
@@ -104,11 +104,7 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
             tracker,
             eliteCount,
             new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -161,11 +157,7 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
             tracker,
             eliteCount,
             new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -216,11 +208,7 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
             replacement,
             tracker,
             new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -271,11 +259,7 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
             replacement,
             tracker,
             new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -664,16 +648,8 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
    * Internal helper constructor for standard EAs with full generation (both crossover and mutation).
    */
   private GenerationalDisjointOperatorsEvolutionaryAlgorithm(
-      Population<T> pop,
-      Problem<T> problem,
-      MutationOperator<T> mutation,
-      double mutationRate,
-      CrossoverOperator<T> crossover,
-      double crossoverRate) {
-    super(
-        pop,
-        problem,
-        new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate));
+      Population<T> pop, Problem<T> problem) {
+    super(pop, problem);
   }
 
   /*

--- a/src/main/java/org/cicirello/search/evo/GenerationalDisjointOperatorsEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalDisjointOperatorsEvolutionaryAlgorithm.java
@@ -96,7 +96,14 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -146,7 +153,14 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -194,7 +208,14 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -242,7 +263,14 @@ public final class GenerationalDisjointOperatorsEvolutionaryAlgorithm<T extends 
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            new MutuallyExclusiveGeneration<T>(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,

--- a/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
@@ -102,11 +102,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
             tracker,
             eliteCount,
             createGeneration(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -155,11 +151,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
             tracker,
             eliteCount,
             createGeneration(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -208,11 +200,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
             replacement,
             tracker,
             createGeneration(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -261,11 +249,7 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
             replacement,
             tracker,
             createGeneration(mutation, mutationRate, crossover, crossoverRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate,
-        crossover,
-        crossoverRate);
+        f.getProblem());
   }
 
   /**
@@ -625,14 +609,8 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
   /*
    * Internal helper constructor for standard EAs with full generation (both crossover and mutation).
    */
-  private GenerationalEvolutionaryAlgorithm(
-      Population<T> pop,
-      Problem<T> problem,
-      MutationOperator<T> mutation,
-      double mutationRate,
-      CrossoverOperator<T> crossover,
-      double crossoverRate) {
-    super(pop, problem, createGeneration(mutation, mutationRate, crossover, crossoverRate));
+  private GenerationalEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
+    super(pop, problem);
   }
 
   private static <T extends Copyable<T>> Generation<T> createGeneration(

--- a/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalEvolutionaryAlgorithm.java
@@ -94,7 +94,14 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            createGeneration(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -140,7 +147,14 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            createGeneration(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -186,7 +200,14 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            createGeneration(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -232,7 +253,14 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            createGeneration(mutation, mutationRate, crossover, crossoverRate)),
         f.getProblem(),
         mutation,
         mutationRate,
@@ -604,12 +632,17 @@ public class GenerationalEvolutionaryAlgorithm<T extends Copyable<T>>
       double mutationRate,
       CrossoverOperator<T> crossover,
       double crossoverRate) {
-    super(
-        pop,
-        problem,
-        mutationRate >= 1.0
-            ? new AlwaysMutateGeneration<T>(mutation, crossover, crossoverRate)
-            : new SimpleGeneration<T>(mutation, mutationRate, crossover, crossoverRate));
+    super(pop, problem, createGeneration(mutation, mutationRate, crossover, crossoverRate));
+  }
+
+  private static <T extends Copyable<T>> Generation<T> createGeneration(
+      MutationOperator<T> mutation,
+      double mutationRate,
+      CrossoverOperator<T> crossover,
+      double crossoverRate) {
+    return mutationRate >= 1.0
+        ? new AlwaysMutateGeneration<T>(mutation, crossover, crossoverRate)
+        : new SimpleGeneration<T>(mutation, mutationRate, crossover, crossoverRate);
   }
 
   /*

--- a/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
@@ -98,9 +98,7 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
             tracker,
             eliteCount,
             createGeneration(mutation, mutationRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate);
+        f.getProblem());
   }
 
   /**
@@ -146,9 +144,7 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
             tracker,
             eliteCount,
             createGeneration(mutation, mutationRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate);
+        f.getProblem());
   }
 
   /**
@@ -193,9 +189,7 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
             replacement,
             tracker,
             createGeneration(mutation, mutationRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate);
+        f.getProblem());
   }
 
   /**
@@ -240,9 +234,7 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
             replacement,
             tracker,
             createGeneration(mutation, mutationRate)),
-        f.getProblem(),
-        mutation,
-        mutationRate);
+        f.getProblem());
   }
 
   /**
@@ -530,9 +522,8 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
   /*
    * Internal helper constructor for Mutation-Only EAs.
    */
-  private GenerationalMutationOnlyEvolutionaryAlgorithm(
-      Population<T> pop, Problem<T> problem, MutationOperator<T> mutation, double mutationRate) {
-    super(pop, problem, createGeneration(mutation, mutationRate));
+  private GenerationalMutationOnlyEvolutionaryAlgorithm(Population<T> pop, Problem<T> problem) {
+    super(pop, problem);
   }
 
   private static <T extends Copyable<T>> Generation<T> createGeneration(

--- a/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/GenerationalMutationOnlyEvolutionaryAlgorithm.java
@@ -90,7 +90,14 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            createGeneration(mutation, mutationRate)),
         f.getProblem(),
         mutation,
         mutationRate);
@@ -131,7 +138,14 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
       int eliteCount,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, tracker, eliteCount),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            tracker,
+            eliteCount,
+            createGeneration(mutation, mutationRate)),
         f.getProblem(),
         mutation,
         mutationRate);
@@ -171,7 +185,14 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.DoubleFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.DoubleFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            createGeneration(mutation, mutationRate)),
         f.getProblem(),
         mutation,
         mutationRate);
@@ -211,7 +232,14 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
       ReplacementStrategy<T> replacement,
       ProgressTracker<T> tracker) {
     this(
-        new BasePopulation.IntegerFitness<T>(n, initializer, f, selection, replacement, tracker),
+        new BasePopulation.IntegerFitness<T>(
+            n,
+            initializer,
+            f,
+            selection,
+            replacement,
+            tracker,
+            createGeneration(mutation, mutationRate)),
         f.getProblem(),
         mutation,
         mutationRate);
@@ -504,12 +532,14 @@ public class GenerationalMutationOnlyEvolutionaryAlgorithm<T extends Copyable<T>
    */
   private GenerationalMutationOnlyEvolutionaryAlgorithm(
       Population<T> pop, Problem<T> problem, MutationOperator<T> mutation, double mutationRate) {
-    super(
-        pop,
-        problem,
-        mutationRate >= 1.0
-            ? new OnlyAlwaysMutateGeneration<T>(mutation)
-            : new OnlyMutateGeneration<T>(mutation, mutationRate));
+    super(pop, problem, createGeneration(mutation, mutationRate));
+  }
+
+  private static <T extends Copyable<T>> Generation<T> createGeneration(
+      MutationOperator<T> mutation, double mutationRate) {
+    return mutationRate >= 1.0
+        ? new OnlyAlwaysMutateGeneration<T>(mutation)
+        : new OnlyMutateGeneration<T>(mutation, mutationRate);
   }
 
   /*

--- a/src/main/java/org/cicirello/search/evo/Population.java
+++ b/src/main/java/org/cicirello/search/evo/Population.java
@@ -93,6 +93,14 @@ interface Population<T extends Copyable<T>> extends Splittable<Population<T>> {
    */
   void initOperators(int generations);
 
+  /**
+   * Performs one full generation: selection, application of evolutionary operators, and replace.
+   *
+   * @param generation the control logic for performing crossover, mutation, etc as needed.
+   * @return The total number of fitness evaluations during the generation.
+   */
+  int generation(Generation<T> generation);
+
   /** Performs selection to choose the population members to undergo genetic operators. */
   void select();
 

--- a/src/main/java/org/cicirello/search/evo/Population.java
+++ b/src/main/java/org/cicirello/search/evo/Population.java
@@ -101,12 +101,6 @@ interface Population<T extends Copyable<T>> extends Splittable<Population<T>> {
    */
   int generation(Generation<T> generation);
 
-  /** Performs selection to choose the population members to undergo genetic operators. */
-  void select();
-
-  /** Updates population based on children of genetic operators. */
-  void replace();
-
   /**
    * Determines whether there is any reason the search should stop, such as if the ProgressTracker
    * contains the best, or if another thread has stopped the ProgressTracker.

--- a/src/main/java/org/cicirello/search/evo/Population.java
+++ b/src/main/java/org/cicirello/search/evo/Population.java
@@ -99,7 +99,7 @@ interface Population<T extends Copyable<T>> extends Splittable<Population<T>> {
    * @param generation the control logic for performing crossover, mutation, etc as needed.
    * @return The total number of fitness evaluations during the generation.
    */
-  int generation(Generation<T> generation);
+  int generation();
 
   /**
    * Determines whether there is any reason the search should stop, such as if the ProgressTracker

--- a/src/test/java/org/cicirello/search/evo/AdaptiveGenerationTests.java
+++ b/src/test/java/org/cicirello/search/evo/AdaptiveGenerationTests.java
@@ -42,15 +42,17 @@ public class AdaptiveGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag = new AdaptiveGeneration<TestObject>(mutation, crossover);
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -73,15 +75,17 @@ public class AdaptiveGenerationTests {
     TestFitnessDouble f = new TestFitnessDouble();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
-        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag = new AdaptiveGeneration<TestObject>(mutation, crossover);
+
+    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
+        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -104,16 +108,18 @@ public class AdaptiveGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag =
         new AdaptiveGeneration<TestObject>(mutation, crossover).split();
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -128,15 +134,17 @@ public class AdaptiveGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag = new AdaptiveGeneration<TestObject>(mutation, crossover);
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -159,15 +167,17 @@ public class AdaptiveGenerationTests {
     TestFitnessDouble f = new TestFitnessDouble();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
-        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag = new AdaptiveGeneration<TestObject>(mutation, crossover);
+
+    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
+        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -190,16 +200,18 @@ public class AdaptiveGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 2);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
     TestCrossover crossover = new TestCrossover();
 
     AdaptiveGeneration<TestObject> ag =
         new AdaptiveGeneration<TestObject>(mutation, crossover).split();
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 2, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();

--- a/src/test/java/org/cicirello/search/evo/AdaptiveMutationOnlyGenerationTests.java
+++ b/src/test/java/org/cicirello/search/evo/AdaptiveMutationOnlyGenerationTests.java
@@ -41,15 +41,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation);
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -72,15 +74,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessDouble f = new TestFitnessDouble();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
-        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation);
+
+    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
+        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -103,15 +107,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N, init, f, selection, tracker, 0, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation).split();
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N, init, f, selection, tracker, 0, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -126,15 +132,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation);
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -157,15 +165,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessDouble f = new TestFitnessDouble();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
-        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation);
+
+    EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
+        new EvolvableParametersPopulation.DoubleFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();
@@ -188,15 +198,17 @@ public class AdaptiveMutationOnlyGenerationTests {
     TestFitnessInteger f = new TestFitnessInteger();
     TestInitializer init = new TestInitializer();
     final int N = 20;
-    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
-        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            N + 1, init, f, selection, tracker, 1, 1);
-    pop.init();
 
     TestMutation mutation = new TestMutation();
 
     AdaptiveMutationOnlyGeneration<TestObject> ag =
         new AdaptiveMutationOnlyGeneration<TestObject>(mutation).split();
+
+    EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
+        new EvolvableParametersPopulation.IntegerFitness<TestObject>(
+            N + 1, init, f, selection, tracker, 1, 1, ag);
+    pop.init();
+
     pop.select();
     int fitnessEvals = ag.apply(pop);
     pop.replace();

--- a/src/test/java/org/cicirello/search/evo/BasePopulationElitistTests.java
+++ b/src/test/java/org/cicirello/search/evo/BasePopulationElitistTests.java
@@ -28,6 +28,14 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for BasePopulation. */
 public class BasePopulationElitistTests extends SharedTestPopulations {
 
+  private SimpleGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation =
+        new SimpleGeneration<TestObject>(new TestMutation(), 0.1, new TestCrossover(), 0.5);
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -40,7 +48,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -51,7 +60,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -62,7 +72,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -73,7 +84,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     null,
-                    1));
+                    1,
+                    generation));
 
     thrown =
         assertThrows(
@@ -85,7 +97,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -96,7 +109,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -107,7 +121,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -118,7 +133,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     null,
-                    1));
+                    1,
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -130,7 +146,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -141,7 +158,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    -1));
+                    -1,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -152,7 +170,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    1));
+                    1,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -163,7 +182,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    -1));
+                    -1,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -174,7 +194,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    10));
+                    10,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -185,7 +206,8 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    10));
+                    10,
+                    generation));
   }
 
   @Test
@@ -196,7 +218,7 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
     TestFitnessDoubleElitist f = new TestFitnessDoubleElitist();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 3);
+            10, new TestInitializer(), f, selection, tracker, 3, generation);
     verifyDoubleElite(
         pop,
         f,
@@ -214,7 +236,7 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            11, new TestInitializer(), f, selection, tracker, 1);
+            11, new TestInitializer(), f, selection, tracker, 1, generation);
     verifySelectCopies(pop);
   }
 
@@ -268,7 +290,7 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
     TestFitnessIntegerElitist f = new TestFitnessIntegerElitist();
     BasePopulation.IntegerFitness<TestObject> pop =
         new BasePopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 3);
+            10, new TestInitializer(), f, selection, tracker, 3, generation);
     verifyIntegerElite(
         pop,
         f,

--- a/src/test/java/org/cicirello/search/evo/BasePopulationElitistTests.java
+++ b/src/test/java/org/cicirello/search/evo/BasePopulationElitistTests.java
@@ -218,7 +218,28 @@ public class BasePopulationElitistTests extends SharedTestPopulations {
     verifySelectCopies(pop);
   }
 
-  void verifySelectCopies(Population<TestObject> pop) {
+  void verifySelectCopies(BasePopulation.DoubleFitness<TestObject> pop) {
+    pop.init();
+    pop.select();
+    TestObject[] firstSelect = new TestObject[10];
+    for (int i = 0; i < 10; i++) {
+      firstSelect[i] = pop.get(i);
+    }
+    pop.replace();
+    pop.select();
+    TestObject[] secondSelect = new TestObject[10];
+    for (int i = 0; i < 10; i++) {
+      secondSelect[i] = pop.get(i);
+    }
+    for (int i = 0; i < 9; i++) {
+      assertFalse(firstSelect[i] == secondSelect[8 - i]);
+      assertFalse(firstSelect[i] == secondSelect[i]);
+      assertEquals(firstSelect[i], secondSelect[8 - i]);
+      assertEquals(firstSelect[i], secondSelect[i]);
+    }
+  }
+
+  void verifySelectCopies(BasePopulation.IntegerFitness<TestObject> pop) {
     pop.init();
     pop.select();
     TestObject[] firstSelect = new TestObject[10];

--- a/src/test/java/org/cicirello/search/evo/BasePopulationReplacementTests.java
+++ b/src/test/java/org/cicirello/search/evo/BasePopulationReplacementTests.java
@@ -28,6 +28,14 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for BasePopulation with specified ReplacementStrategy. */
 public class BasePopulationReplacementTests extends SharedTestPopulations {
 
+  private SimpleGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation =
+        new SimpleGeneration<TestObject>(new TestMutation(), 0.1, new TestCrossover(), 0.5);
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -40,7 +48,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -51,7 +60,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -62,7 +72,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     null,
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -73,7 +84,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    null));
+                    null,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -84,7 +96,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     null,
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
 
     thrown =
         assertThrows(
@@ -96,7 +109,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -107,7 +121,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -118,7 +133,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     null,
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -129,7 +145,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    null));
+                    null,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -140,7 +157,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     null,
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -152,7 +170,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -163,7 +182,8 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
-                    new ProgressTracker<TestObject>()));
+                    new ProgressTracker<TestObject>(),
+                    generation));
   }
 
   @Test
@@ -175,7 +195,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifyDouble(
         pop,
         f,
@@ -194,7 +214,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifySelectCopies(pop);
   }
 
@@ -207,7 +227,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifyDoubleWithIntCost(
         pop,
         f,
@@ -226,7 +246,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifySelectCopies(pop);
   }
 
@@ -239,7 +259,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.IntegerFitness<TestObject> pop =
         new BasePopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifyInteger(
         pop,
         f,
@@ -258,7 +278,7 @@ public class BasePopulationReplacementTests extends SharedTestPopulations {
     GenerationalReplacement<TestObject> r = new GenerationalReplacement<TestObject>();
     BasePopulation.IntegerFitness<TestObject> pop =
         new BasePopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, r, tracker);
+            10, new TestInitializer(), f, selection, r, tracker, generation);
     verifySelectCopies(pop);
   }
 }

--- a/src/test/java/org/cicirello/search/evo/BasePopulationTests.java
+++ b/src/test/java/org/cicirello/search/evo/BasePopulationTests.java
@@ -28,6 +28,14 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for BasePopulation. */
 public class BasePopulationTests extends SharedTestPopulations {
 
+  private SimpleGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation =
+        new SimpleGeneration<TestObject>(new TestMutation(), 0.1, new TestCrossover(), 0.5);
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -40,7 +48,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -51,7 +60,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -62,7 +72,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -73,7 +84,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     null,
-                    0));
+                    0,
+                    generation));
 
     thrown =
         assertThrows(
@@ -85,7 +97,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -96,7 +109,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     null,
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -107,7 +121,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -118,7 +133,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     null,
-                    0));
+                    0,
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -130,7 +146,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessDouble(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -141,7 +158,8 @@ public class BasePopulationTests extends SharedTestPopulations {
                     new TestFitnessInteger(),
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
-                    0));
+                    0,
+                    generation));
   }
 
   @Test
@@ -152,7 +170,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifyDouble(
         pop,
         f,
@@ -170,7 +188,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifySelectCopies(pop);
   }
 
@@ -182,7 +200,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifyDoubleWithIntCost(
         pop,
         f,
@@ -200,7 +218,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     BasePopulation.DoubleFitness<TestObject> pop =
         new BasePopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifySelectCopies(pop);
   }
 
@@ -212,7 +230,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessInteger f = new TestFitnessInteger();
     BasePopulation.IntegerFitness<TestObject> pop =
         new BasePopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifyInteger(
         pop,
         f,
@@ -230,7 +248,7 @@ public class BasePopulationTests extends SharedTestPopulations {
     TestFitnessInteger f = new TestFitnessInteger();
     BasePopulation.IntegerFitness<TestObject> pop =
         new BasePopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0);
+            10, new TestInitializer(), f, selection, tracker, 0, generation);
     verifySelectCopies(pop);
   }
 
@@ -251,7 +269,8 @@ public class BasePopulationTests extends SharedTestPopulations {
             (candidate, fitness) ->
                 new PopulationMember.DoubleFitness<TestObject>(candidate, fitness),
             0,
-            replacement);
+            replacement,
+            generation);
     pop.init();
     pop.select(); // 2, 3, 4, 5, 6, 5, 4, 3, 2, 1
     pop.replace();
@@ -289,7 +308,8 @@ public class BasePopulationTests extends SharedTestPopulations {
             (candidate, fitness) ->
                 new PopulationMember.IntegerFitness<TestObject>(candidate, fitness),
             0,
-            replacement);
+            replacement,
+            generation);
     pop.init();
     pop.select(); // 2, 3, 4, 5, 6, 5, 4, 3, 2, 1
     pop.replace();

--- a/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationElitistTests.java
+++ b/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationElitistTests.java
@@ -28,6 +28,13 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for EvolvableParametersPopulation. */
 public class EvolvableParametersPopulationElitistTests extends SharedTestPopulations {
 
+  private AdaptiveGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation = new AdaptiveGeneration<TestObject>(new TestMutation(), new TestCrossover());
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -41,7 +48,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -53,7 +61,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -65,7 +74,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     null,
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -77,7 +87,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     null,
                     1,
-                    2));
+                    2,
+                    generation));
 
     thrown =
         assertThrows(
@@ -90,7 +101,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -102,7 +114,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -114,7 +127,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     null,
                     new ProgressTracker<TestObject>(),
                     1,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -126,7 +140,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     null,
                     1,
-                    2));
+                    2,
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -139,7 +154,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -151,7 +167,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -163,7 +180,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     -1,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -175,7 +193,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     -1,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -187,7 +206,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     10,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -199,7 +219,8 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     10,
-                    2));
+                    2,
+                    generation));
   }
 
   @Test
@@ -210,7 +231,7 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
     TestFitnessDoubleElitist f = new TestFitnessDoubleElitist();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 3, 2);
+            10, new TestInitializer(), f, selection, tracker, 3, 2, generation);
     verifyDoubleElite(
         pop,
         f,
@@ -232,7 +253,7 @@ public class EvolvableParametersPopulationElitistTests extends SharedTestPopulat
     TestFitnessIntegerElitist f = new TestFitnessIntegerElitist();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 3, 2);
+            10, new TestInitializer(), f, selection, tracker, 3, 2, generation);
     verifyIntegerElite(
         pop,
         f,

--- a/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationReplacementTests.java
+++ b/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationReplacementTests.java
@@ -28,6 +28,13 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for EvolvableParametersPopulation with customized ReplacementStrategy. */
 public class EvolvableParametersPopulationReplacementTests extends SharedTestPopulations {
 
+  private AdaptiveGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation = new AdaptiveGeneration<TestObject>(new TestMutation(), new TestCrossover());
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -41,7 +48,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -53,7 +61,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -65,7 +74,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     null,
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -77,7 +87,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     null,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -89,7 +100,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
 
     thrown =
         assertThrows(
@@ -102,7 +114,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -114,7 +127,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -126,7 +140,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     null,
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -138,7 +153,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     null,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -150,7 +166,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     null,
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -163,7 +180,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -175,7 +193,8 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
                     new TestSelectionOp(),
                     new GenerationalReplacement<TestObject>(),
                     new ProgressTracker<TestObject>(),
-                    2));
+                    2,
+                    generation));
   }
 
   @Test
@@ -187,7 +206,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     GenerationalReplacement<TestObject> replacement = new GenerationalReplacement<TestObject>();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     pop.init();
     pop.select();
     boolean allSame0 = true;
@@ -215,7 +234,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
 
     pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 1);
+            10, new TestInitializer(), f, selection, replacement, tracker, 1, generation);
     pop.init();
     pop.select();
     allSame0 = true;
@@ -241,7 +260,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     pop.init();
     pop.select();
     boolean allSame0 = true;
@@ -269,7 +288,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
 
     pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 1);
+            10, new TestInitializer(), f, selection, replacement, tracker, 1, generation);
     pop.init();
     pop.select();
     allSame0 = true;
@@ -295,7 +314,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessDouble f = new TestFitnessDouble();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifyDouble(
         pop,
         f,
@@ -318,7 +337,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessDouble f = new TestFitnessDouble();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifySelectCopies(pop);
   }
 
@@ -331,7 +350,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifyDoubleWithIntCost(
         pop,
         f,
@@ -350,7 +369,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifySelectCopies(pop);
   }
 
@@ -363,7 +382,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifyInteger(
         pop,
         f,
@@ -386,7 +405,7 @@ public class EvolvableParametersPopulationReplacementTests extends SharedTestPop
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, replacement, tracker, 2);
+            10, new TestInitializer(), f, selection, replacement, tracker, 2, generation);
     verifySelectCopies(pop);
   }
 }

--- a/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationTests.java
+++ b/src/test/java/org/cicirello/search/evo/EvolvableParametersPopulationTests.java
@@ -28,6 +28,13 @@ import org.junit.jupiter.api.*;
 /** JUnit test cases for EvolvableParametersPopulation. */
 public class EvolvableParametersPopulationTests extends SharedTestPopulations {
 
+  private AdaptiveGeneration<TestObject> generation;
+
+  @BeforeEach
+  public void initTest() {
+    generation = new AdaptiveGeneration<TestObject>(new TestMutation(), new TestCrossover());
+  }
+
   @Test
   public void testExceptions() {
     NullPointerException thrown =
@@ -41,7 +48,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -53,7 +61,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -65,7 +74,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     null,
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -77,7 +87,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     null,
                     0,
-                    2));
+                    2,
+                    generation));
 
     thrown =
         assertThrows(
@@ -90,7 +101,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -102,7 +114,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -114,7 +127,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     null,
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown =
         assertThrows(
             NullPointerException.class,
@@ -126,7 +140,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     null,
                     0,
-                    2));
+                    2,
+                    generation));
 
     IllegalArgumentException thrown2 =
         assertThrows(
@@ -139,7 +154,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
     thrown2 =
         assertThrows(
             IllegalArgumentException.class,
@@ -151,7 +167,8 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
                     new TestSelectionOp(),
                     new ProgressTracker<TestObject>(),
                     0,
-                    2));
+                    2,
+                    generation));
   }
 
   @Test
@@ -162,7 +179,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     pop.init();
     pop.select();
     boolean allSame0 = true;
@@ -190,7 +207,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
 
     pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 1);
+            10, new TestInitializer(), f, selection, tracker, 0, 1, generation);
     pop.init();
     pop.select();
     allSame0 = true;
@@ -215,7 +232,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     pop.init();
     pop.select();
     boolean allSame0 = true;
@@ -243,7 +260,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
 
     pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 1);
+            10, new TestInitializer(), f, selection, tracker, 0, 1, generation);
     pop.init();
     pop.select();
     allSame0 = true;
@@ -268,7 +285,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifyDouble(
         pop,
         f,
@@ -290,7 +307,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessDouble f = new TestFitnessDouble();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifySelectCopies(pop);
   }
 
@@ -302,7 +319,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifyDoubleWithIntCost(
         pop,
         f,
@@ -320,7 +337,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessDoubleIntCost f = new TestFitnessDoubleIntCost();
     EvolvableParametersPopulation.DoubleFitness<TestObject> pop =
         new EvolvableParametersPopulation.DoubleFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifySelectCopies(pop);
   }
 
@@ -332,7 +349,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifyInteger(
         pop,
         f,
@@ -354,7 +371,7 @@ public class EvolvableParametersPopulationTests extends SharedTestPopulations {
     TestFitnessInteger f = new TestFitnessInteger();
     EvolvableParametersPopulation.IntegerFitness<TestObject> pop =
         new EvolvableParametersPopulation.IntegerFitness<TestObject>(
-            10, new TestInitializer(), f, selection, tracker, 0, 2);
+            10, new TestInitializer(), f, selection, tracker, 0, 2, generation);
     verifySelectCopies(pop);
   }
 }

--- a/src/test/java/org/cicirello/search/evo/SharedTestPopulations.java
+++ b/src/test/java/org/cicirello/search/evo/SharedTestPopulations.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import org.cicirello.search.ProgressTracker;
+import org.cicirello.search.operators.CrossoverOperator;
 import org.cicirello.search.operators.Initializer;
+import org.cicirello.search.operators.MutationOperator;
 import org.cicirello.search.problems.IntegerCostOptimizationProblem;
 import org.cicirello.search.problems.OptimizationProblem;
 import org.cicirello.search.problems.Problem;
@@ -930,6 +932,32 @@ public class SharedTestPopulations {
     }
 
     public TestInitializer split() {
+      return this;
+    }
+  }
+
+  static class TestMutation implements MutationOperator<TestObject> {
+
+    @Override
+    public void mutate(TestObject p) {
+      // do nothing
+    }
+
+    @Override
+    public TestMutation split() {
+      return this;
+    }
+  }
+
+  static class TestCrossover implements CrossoverOperator<TestObject> {
+
+    @Override
+    public void cross(TestObject p1, TestObject p2) {
+      // do nothing
+    }
+
+    @Override
+    public TestCrossover split() {
       return this;
     }
   }

--- a/src/test/java/org/cicirello/search/evo/SharedTestPopulations.java
+++ b/src/test/java/org/cicirello/search/evo/SharedTestPopulations.java
@@ -36,14 +36,13 @@ import org.junit.jupiter.api.*;
 public class SharedTestPopulations {
 
   void verifyInteger(
-      BasePopulation.IntegerFitness popVector,
+      BasePopulation.IntegerFitness<TestObject> popVector,
       TestFitnessInteger f,
       ProgressTracker<TestObject> tracker,
       TestSelectionOp selection,
       ToIntFunction<Population<TestObject>> mostFitFitness,
       int elite) {
-    @SuppressWarnings("unchecked")
-    Population<TestObject> pop = (Population<TestObject>) popVector;
+    BasePopulation.IntegerFitness<TestObject> pop = popVector;
 
     assertTrue(tracker == pop.getProgressTracker());
     tracker = new ProgressTracker<TestObject>();
@@ -124,9 +123,9 @@ public class SharedTestPopulations {
     }
 
     f.changeFitness(12);
-    Population<TestObject> pop2 = pop.split();
+    BasePopulation.IntegerFitness<TestObject> pop2 = pop.split();
     @SuppressWarnings("unchecked")
-    BasePopulation.IntegerFitness popVector2 = (BasePopulation.IntegerFitness) pop2;
+    BasePopulation.IntegerFitness<TestObject> popVector2 = pop2;
 
     if (elite == 0) {
       // orginal should be same
@@ -170,14 +169,13 @@ public class SharedTestPopulations {
   }
 
   void verifyDoubleWithIntCost(
-      BasePopulation.DoubleFitness popVector,
+      BasePopulation.DoubleFitness<TestObject> popVector,
       TestFitnessDoubleIntCost f,
       ProgressTracker<TestObject> tracker,
       TestSelectionOp selection,
       ToDoubleFunction<Population<TestObject>> mostFitFitness,
       int elite) {
-    @SuppressWarnings("unchecked")
-    Population<TestObject> pop = (Population<TestObject>) popVector;
+    BasePopulation.DoubleFitness<TestObject> pop = popVector;
 
     assertTrue(tracker == pop.getProgressTracker());
     tracker = new ProgressTracker<TestObject>();
@@ -232,9 +230,8 @@ public class SharedTestPopulations {
     assertEquals(98, pop.getMostFit().getCost());
 
     f.changeFitness(12);
-    Population<TestObject> pop2 = pop.split();
-    @SuppressWarnings("unchecked")
-    BasePopulation.DoubleFitness popVector2 = (BasePopulation.DoubleFitness) pop2;
+    BasePopulation.DoubleFitness<TestObject> pop2 = pop.split();
+    BasePopulation.DoubleFitness<TestObject> popVector2 = pop2;
 
     // orginal should be same
     assertEquals(expected[9] + 10.0 + 1, popVector.fitness(0));
@@ -267,14 +264,13 @@ public class SharedTestPopulations {
   }
 
   void verifyDouble(
-      BasePopulation.DoubleFitness popVector,
+      BasePopulation.DoubleFitness<TestObject> popVector,
       TestFitnessDouble f,
       ProgressTracker<TestObject> tracker,
       TestSelectionOp selection,
       ToDoubleFunction<Population<TestObject>> mostFitFitness,
       int elite) {
-    @SuppressWarnings("unchecked")
-    Population<TestObject> pop = (Population<TestObject>) popVector;
+    BasePopulation.DoubleFitness<TestObject> pop = popVector;
 
     assertTrue(tracker == pop.getProgressTracker());
     tracker = new ProgressTracker<TestObject>();
@@ -355,9 +351,8 @@ public class SharedTestPopulations {
     }
 
     f.changeFitness(12);
-    Population<TestObject> pop2 = pop.split();
-    @SuppressWarnings("unchecked")
-    BasePopulation.DoubleFitness popVector2 = (BasePopulation.DoubleFitness) pop2;
+    BasePopulation.DoubleFitness<TestObject> pop2 = pop.split();
+    BasePopulation.DoubleFitness<TestObject> popVector2 = pop2;
 
     // orginal should be same
     assertEquals(expected[9] + 0.4 + 1 + eliteAdjust, popVector.fitness(eliteAdjust));
@@ -389,7 +384,26 @@ public class SharedTestPopulations {
     assertTrue(pop2.evolutionIsPaused());
   }
 
-  void verifySelectCopies(Population<TestObject> pop) {
+  void verifySelectCopies(BasePopulation.IntegerFitness<TestObject> pop) {
+    pop.init();
+    pop.select();
+    TestObject[] firstSelect = new TestObject[10];
+    for (int i = 0; i < 10; i++) {
+      firstSelect[i] = pop.get(i);
+    }
+    pop.replace();
+    pop.select();
+    TestObject[] secondSelect = new TestObject[10];
+    for (int i = 0; i < 10; i++) {
+      secondSelect[i] = pop.get(i);
+    }
+    for (int i = 0; i < 10; i++) {
+      assertFalse(firstSelect[i] == secondSelect[9 - i]);
+      assertEquals(firstSelect[i], secondSelect[9 - i]);
+    }
+  }
+
+  void verifySelectCopies(BasePopulation.DoubleFitness<TestObject> pop) {
     pop.init();
     pop.select();
     TestObject[] firstSelect = new TestObject[10];
@@ -409,14 +423,13 @@ public class SharedTestPopulations {
   }
 
   void verifyIntegerElite(
-      BasePopulation.IntegerFitness popVector,
+      BasePopulation.IntegerFitness<TestObject> popVector,
       TestFitnessIntegerElitist f,
       ProgressTracker<TestObject> tracker,
       TestSelectionOp selection,
       ToIntFunction<Population<TestObject>> mostFitFitness,
       int elite) {
-    @SuppressWarnings("unchecked")
-    Population<TestObject> pop = (Population<TestObject>) popVector;
+    BasePopulation.IntegerFitness<TestObject> pop = popVector;
 
     assertTrue(tracker == pop.getProgressTracker());
     tracker = new ProgressTracker<TestObject>();
@@ -533,9 +546,8 @@ public class SharedTestPopulations {
     assertEquals(tracker.getSolution(), pop.getMostFit().getSolution());
 
     f.changeFitness(12);
-    Population<TestObject> pop2 = pop.split();
-    @SuppressWarnings("unchecked")
-    BasePopulation.IntegerFitness popVector2 = (BasePopulation.IntegerFitness) pop2;
+    BasePopulation.IntegerFitness<TestObject> pop2 = pop.split();
+    BasePopulation.IntegerFitness<TestObject> popVector2 = pop2;
 
     // orginal should be same
     assertEquals(
@@ -568,14 +580,13 @@ public class SharedTestPopulations {
   }
 
   void verifyDoubleElite(
-      BasePopulation.DoubleFitness popVector,
+      BasePopulation.DoubleFitness<TestObject> popVector,
       TestFitnessDoubleElitist f,
       ProgressTracker<TestObject> tracker,
       TestSelectionOp selection,
       ToDoubleFunction<Population<TestObject>> mostFitFitness,
       int elite) {
-    @SuppressWarnings("unchecked")
-    Population<TestObject> pop = (Population<TestObject>) popVector;
+    BasePopulation.DoubleFitness<TestObject> pop = popVector;
 
     assertTrue(tracker == pop.getProgressTracker());
     tracker = new ProgressTracker<TestObject>();
@@ -694,9 +705,8 @@ public class SharedTestPopulations {
     assertEquals(tracker.getSolution(), pop.getMostFit().getSolution());
 
     f.changeFitness(12);
-    Population<TestObject> pop2 = pop.split();
-    @SuppressWarnings("unchecked")
-    BasePopulation.DoubleFitness popVector2 = (BasePopulation.DoubleFitness) pop2;
+    BasePopulation.DoubleFitness<TestObject> pop2 = pop.split();
+    BasePopulation.DoubleFitness<TestObject> popVector2 = pop2;
 
     // orginal should be same
     assertEquals(


### PR DESCRIPTION
## Summary
Refactored to move Generation instance from AbstractEvolutionaryAlgorithm class into BasePopulation class. This is cleaner. It will also make it easier to integrate planned additional evolutionary algorithms. This is non-breaking as all changes are in package access classes and interfaces.

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
