### PR TITLE
added fitnessAsDouble method to PopulationFitnessVector interface

### DIFF
--- a/src/main/java/org/cicirello/search/Metaheuristic.java
+++ b/src/main/java/org/cicirello/search/Metaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -29,7 +29,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.9.2020
  */
 public interface Metaheuristic<T extends Copyable<T>> extends TrackableSearch<T> {
 

--- a/src/main/java/org/cicirello/search/ProgressTracker.java
+++ b/src/main/java/org/cicirello/search/ProgressTracker.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2023 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *

--- a/src/main/java/org/cicirello/search/ReoptimizableMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/ReoptimizableMetaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -30,7 +30,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.9.2020
  */
 public interface ReoptimizableMetaheuristic<T extends Copyable<T>> extends Metaheuristic<T> {
 

--- a/src/main/java/org/cicirello/search/SimpleLocalMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/SimpleLocalMetaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -30,7 +30,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.9.2020
  */
 public interface SimpleLocalMetaheuristic<T extends Copyable<T>> extends SimpleMetaheuristic<T> {
 

--- a/src/main/java/org/cicirello/search/SimpleMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/SimpleMetaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2024 Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -29,7 +29,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 5.9.2020
  */
 public interface SimpleMetaheuristic<T extends Copyable<T>> extends TrackableSearch<T> {
 

--- a/src/main/java/org/cicirello/search/SingleSolutionMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/SingleSolutionMetaheuristic.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -31,7 +31,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 10.11.2019
  */
 public interface SingleSolutionMetaheuristic<T extends Copyable<T>>
     extends ReoptimizableMetaheuristic<T> {
@@ -55,4 +54,7 @@ public interface SingleSolutionMetaheuristic<T extends Copyable<T>>
    *     theoretical best solution.
    */
   SolutionCostPair<T> optimize(int runLength, T start);
+
+  @Override
+  SingleSolutionMetaheuristic<T> split();
 }

--- a/src/main/java/org/cicirello/search/TrackableSearch.java
+++ b/src/main/java/org/cicirello/search/TrackableSearch.java
@@ -1,6 +1,6 @@
 /*
  * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
- * Copyright (C) 2002-2020  Vincent A. Cicirello
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
  *
  * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
  *
@@ -32,7 +32,6 @@ import org.cicirello.util.Copyable;
  * @param <T> The type of object under optimization.
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 6.15.2020
  */
 public interface TrackableSearch<T extends Copyable<T>> extends Splittable<TrackableSearch<T>> {
 

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -139,8 +139,8 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
    * best solution, and also immediately returns if a prior call found the theoretical best. In such
    * cases, the total run length may be less than the requested run length.
    *
-   * @return The total number of generations completed across all calls to {@link #optimize} and
-   *     {@link #reoptimize}.
+   * @return The total run length in number of fitness evaluations across all calls to {@link
+   *     #optimize} and {@link #reoptimize}.
    */
   @Override
   public long getTotalRunLength() {

--- a/src/main/java/org/cicirello/search/evo/BNPReplacement.java
+++ b/src/main/java/org/cicirello/search/evo/BNPReplacement.java
@@ -235,13 +235,13 @@ public final class BNPReplacement<T> implements ReplacementStrategy<T> {
     for (int i = 0; i < parentPopulation.size(); i++) {
       allIndividuals.add(
           new Individual<>(
-              individualId, parentPopulation.candidate(i), getFitness(parentPopulation, i)));
+              individualId, parentPopulation.candidate(i), parentPopulation.fitnessAsDouble(i)));
       individualId++;
     }
     for (int i = 0; i < childPopulation.size(); i++) {
       allIndividuals.add(
           new Individual<>(
-              individualId, childPopulation.candidate(i), getFitness(childPopulation, i)));
+              individualId, childPopulation.candidate(i), childPopulation.fitnessAsDouble(i)));
       individualId++;
     }
 
@@ -313,31 +313,6 @@ public final class BNPReplacement<T> implements ReplacementStrategy<T> {
       allIndividuals.removeLast();
       survivorCount++;
     }
-  }
-
-  /**
-   * Returns the fitness of a candidate solution given its index. The method determines the type of
-   * population (either double or integer fitness) and retrieves the corresponding fitness value.
-   * This is an auxilar method to abstract the internal replace functionality.
-   *
-   * @param population The population of candidate solutions, which can be of type {@code
-   *     PopulationCandidates.DoubleFitness} or {@code PopulationCandidates.IntegerFitness}.
-   * @param index The index of the candidate whose fitness is to be retrieved.
-   * @return The fitness value of the candidate at the specified index. If the population is of type
-   *     {@code PopulationCandidates.DoubleFitness}, the exact fitness value is returned. If the
-   *     population is of type {@code PopulationCandidates.IntegerFitness}, the fitness value is
-   *     cast to a double.
-   */
-  private double getFitness(PopulationCandidates<?> population, int index) {
-    // only two possible cases, so this default value should never be returned
-    double fitness = -1;
-    if (population instanceof PopulationCandidates.DoubleFitness casted) {
-      fitness = casted.fitness(index);
-    }
-    if (population instanceof PopulationCandidates.IntegerFitness casted) {
-      fitness = casted.fitness(index);
-    }
-    return fitness;
   }
 
   /**

--- a/src/main/java/org/cicirello/search/evo/PopulationFitnessVector.java
+++ b/src/main/java/org/cicirello/search/evo/PopulationFitnessVector.java
@@ -36,6 +36,19 @@ public interface PopulationFitnessVector {
   int size();
 
   /**
+   * The fitness of the a member of the population represented as a double. For implementations of
+   * the {@link DoubleFitness} interface, this is the same as the {@link DoubleFitness#fitness}
+   * method. For implementations of the {@link IntegerFitness} interface, this method simply returns
+   * {@link IntegerFitness#fitness}. This method is provided as a convenience for cases where you
+   * cannot exploit integer-valued fitnesses for code optimization. Thus utilizing the
+   * fitnessAsDouble method may lead to simplified code.
+   *
+   * @param i The index into the population, which must be in the interval [0, size()).
+   * @return the fitness of population member i.
+   */
+  double fitnessAsDouble(int i);
+
+  /**
    * An interface to a vector of fitnesses, each an int, of a population.
    *
    * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
@@ -50,6 +63,11 @@ public interface PopulationFitnessVector {
      * @return the fitness of population member i.
      */
     int fitness(int i);
+
+    @Override
+    default double fitnessAsDouble(int i) {
+      return fitness(i);
+    }
 
     /**
      * Creates a PopulationFitnessVector.IntegerFitness wrapping a primitive int array.
@@ -122,6 +140,11 @@ public interface PopulationFitnessVector {
      * @return the fitness of population member i.
      */
     double fitness(int i);
+
+    @Override
+    default double fitnessAsDouble(int i) {
+      return fitness(i);
+    }
 
     /**
      * Creates a PopulationFitnessVector.DoubleFitness wrapping a primitive double array.


### PR DESCRIPTION
## Summary
Added fitnessAsDouble method to PopulationFitnessVector interface, which enables simplifying code when one cannot exploit the int fitness values of the PopulationFitnessVector.IntegerFitness subinterface for any meaningful optimization.

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
