### PR TITLE
added TerminationStrategy interface to enable customizing termination criteria of EAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-09-03
+## [Unreleased] - 2026-09-07
 
 ### Added
+* TerminationStrategy interface to enable specifying termination criteria other than maximum number of generations
+* A new optimize(numberOfGenerations, TerminationStrategy) method to all of the evolutionary algorithms that accepts an instance of an implementation of the new TerminationStrategy interface
 * Best-non-penalized (BNP) replacement strategy (@alex-cornejo)
 
 ### Changed (Non-Breaking)
 * Minor code improvements to implementations of equals methods in a few classes
 * Refactored: moved Generation instance from AbstractEvolutionaryAlgorithm class into BasePopulation class
-* Optimized GenerationalElitistReplacement, including handling the case of a single elite separately from general case (e.g., simple linear time iteration for single elite versus binary heap for k elite).
+* Optimized GenerationalElitistReplacement, including handling the case of a single elite separately from general case (e.g., simple linear time iteration for single elite versus binary heap for k elite)
 
 ### Changed (Breaking)
 

--- a/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
+++ b/src/main/java/org/cicirello/search/evo/AbstractEvolutionaryAlgorithm.java
@@ -21,7 +21,6 @@
 package org.cicirello.search.evo;
 
 import org.cicirello.search.ProgressTracker;
-import org.cicirello.search.ReoptimizableMetaheuristic;
 import org.cicirello.search.SolutionCostPair;
 import org.cicirello.search.problems.Problem;
 import org.cicirello.util.Copyable;
@@ -34,7 +33,7 @@ import org.cicirello.util.Copyable;
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
-    implements ReoptimizableMetaheuristic<T> {
+    implements PopulationMetaheuristic<T> {
 
   private final Population<T> pop;
   private final Problem<T> problem;
@@ -89,7 +88,37 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
     optimizeCalled = true;
     pop.initOperators(numGenerations);
     numFitnessEvals = numFitnessEvals + pop.size();
-    internalOptimize(numGenerations);
+    internalOptimize(s -> s.numCompletedGenerations() >= numGenerations, pop.size());
+    return pop.getMostFit();
+  }
+
+  /**
+   * Runs the evolutionary algorithm beginning from a randomly generated population. If this method
+   * is called multiple times, each call begins at a new randomly generated population.
+   *
+   * @param numGenerations The maximum number of generations, which will cause the run to terminate
+   *     even if other criteria specified in the terminator are not currently met. Some selection
+   *     operators and replacement strategies may need to know the maximum number of generations to
+   *     operate properly, which is why this parameter is needed separately from other termination
+   *     criteria.
+   * @param terminator the termination criteria. Your terminator does not need to monitor for
+   *     maximum number of generations. That is done for you.
+   * @return The best solution found during this call to optimize, which may or may not be the same
+   *     as the solution contained in the {@link ProgressTracker}, which contains the best across
+   *     all calls to optimize as well as {@link #reoptimize}. Returns null if the run did not
+   *     execute, such as if the ProgressTracker already contains the theoretical best solution.
+   */
+  @Override
+  public final SolutionCostPair<T> optimize(int numGenerations, TerminationStrategy<T> terminator) {
+    if (pop.evolutionIsPaused()) {
+      return null;
+    }
+    pop.init();
+    optimizeCalled = true;
+    pop.initOperators(numGenerations);
+    numFitnessEvals = numFitnessEvals + pop.size();
+    internalOptimize(
+        s -> s.numCompletedGenerations() >= numGenerations || terminator.terminate(s), pop.size());
     return pop.getMostFit();
   }
 
@@ -113,7 +142,7 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
       return null;
     }
     pop.initOperators(numGenerations);
-    internalOptimize(numGenerations);
+    internalOptimize(s -> s.numCompletedGenerations() >= numGenerations, 0);
     return pop.getMostFit();
   }
 
@@ -150,9 +179,23 @@ abstract class AbstractEvolutionaryAlgorithm<T extends Copyable<T>>
   @Override
   public abstract AbstractEvolutionaryAlgorithm<T> split();
 
-  private void internalOptimize(int numGenerations) {
-    for (int i = 0; i < numGenerations && !pop.evolutionIsPaused(); i++) {
-      numFitnessEvals = numFitnessEvals + pop.generation();
+  private void internalOptimize(
+      TerminationStrategy<T> terminator, long thisRunsFitnessEvaluations) {
+    for (int i = 0;
+        !terminator.terminate(
+                new TerminationStrategy.ExecutionState<T>(
+                    i,
+                    thisRunsFitnessEvaluations,
+                    pop.getMostFit().getSolution(),
+                    pop.bestFitness(),
+                    pop.currentPopulation()))
+            && !pop.evolutionIsPaused();
+        i++) {
+      int generationsFitnessEvals = pop.generation();
+      // Total fitness evaluations across all runs
+      numFitnessEvals = numFitnessEvals + generationsFitnessEvals;
+      // Total fitness evaluations for this run only.
+      thisRunsFitnessEvaluations = thisRunsFitnessEvaluations + generationsFitnessEvals;
     }
   }
 }

--- a/src/main/java/org/cicirello/search/evo/BasePopulation.java
+++ b/src/main/java/org/cicirello/search/evo/BasePopulation.java
@@ -241,6 +241,16 @@ abstract class BasePopulation {
     }
 
     @Override
+    public final double bestFitness() {
+      return bestFitness;
+    }
+
+    @Override
+    public final PopulationCandidates<T> currentPopulation() {
+      return pop;
+    }
+
+    @Override
     public final void updateFitness(int i) {
       double fit = f.fitness(nextPop.candidate(i));
       nextPop.get(i).setFitness(fit);
@@ -536,6 +546,16 @@ abstract class BasePopulation {
      */
     public final int getFitnessOfMostFit() {
       return bestFitness;
+    }
+
+    @Override
+    public final double bestFitness() {
+      return bestFitness;
+    }
+
+    @Override
+    public final PopulationCandidates<T> currentPopulation() {
+      return pop;
     }
 
     @Override

--- a/src/main/java/org/cicirello/search/evo/Population.java
+++ b/src/main/java/org/cicirello/search/evo/Population.java
@@ -77,6 +77,22 @@ interface Population<T extends Copyable<T>> extends Splittable<Population<T>> {
   SolutionCostPair<T> getMostFit();
 
   /**
+   * Gets the fitness of the most fit candidate solution found in any generation as a double value.
+   *
+   * @return the fitness of the most fit solution encountered in any generation (as a value of type
+   *     double)
+   */
+  double bestFitness();
+
+  /**
+   * Gets the current population, enabling access by components that may need to reason about the
+   * underlying population such as termination strategies, replacement strategies, etc.
+   *
+   * @return the current population
+   */
+  PopulationCandidates<T> currentPopulation();
+
+  /**
    * Update the fitness of a candidate solution for the next generation.
    *
    * @param i The population member.

--- a/src/main/java/org/cicirello/search/evo/PopulationCandidates.java
+++ b/src/main/java/org/cicirello/search/evo/PopulationCandidates.java
@@ -21,8 +21,9 @@
 package org.cicirello.search.evo;
 
 /**
- * An interface to the candidates for the next generation's population, consisting of the current
- * population as well as the relevant pool of children.
+ * An interface to candidates for the next generation's population, which can be the current members
+ * of the population or the children derived from it, depending upon the context. This interface is
+ * used as a parameter to the {@link ReplacementStrategy} interface.
  *
  * @param <T> the representation of population members
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
@@ -45,9 +46,9 @@ public interface PopulationCandidates<T> extends PopulationFitnessVector {
   T candidate(int i);
 
   /**
-   * An interface to the candidates for the next generation's population, consisting of the current
-   * population as well as the relevant pool of children. This interface is for the case when
-   * fitness values are ints.
+   * An interface to the candidates for the next generation's population, which can be the current
+   * members of the population or the children derived from it, depending upon the context. This
+   * interface is for the case when fitness values are ints.
    *
    * @param <T> the representation of population members
    * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
@@ -57,9 +58,9 @@ public interface PopulationCandidates<T> extends PopulationFitnessVector {
       extends PopulationCandidates<T>, PopulationFitnessVector.IntegerFitness {}
 
   /**
-   * An interface to the candidates for the next generation's population, consisting of the current
-   * population as well as the relevant pool of children. This interface is for the case when
-   * fitness values are doubles.
+   * An interface to the candidates for the next generation's population, which can be the current
+   * members of the population or the children derived from it, depending upon the context. This
+   * interface is for the case when fitness values are doubles.
    *
    * @param <T> the representation of population members
    * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a

--- a/src/main/java/org/cicirello/search/evo/PopulationMetaheuristic.java
+++ b/src/main/java/org/cicirello/search/evo/PopulationMetaheuristic.java
@@ -1,0 +1,63 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ *
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+import org.cicirello.search.ReoptimizableMetaheuristic;
+import org.cicirello.search.SolutionCostPair;
+import org.cicirello.util.Copyable;
+
+/**
+ * This interface defines the required methods for implementations of metaheuristics that maintain a
+ * population of candidate solutions such as evolutionary algorithms. The primary additional
+ * functionality defined over that already included in the parent interface is the ability to define
+ * termination criteria based on the state of the underlying population of solutions.
+ *
+ * @param <T> The type of object under optimization.
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
+ *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public interface PopulationMetaheuristic<T extends Copyable<T>>
+    extends ReoptimizableMetaheuristic<T> {
+
+  /**
+   * Executes a run of the metaheuristic beginning at a randomly generated population of solutions.
+   * If this method is called multiple times, each call begins at a new randomly generated starting
+   * population, and reinitializes any control parameters of the metaheuristic that may have changed
+   * during the previous call to optimize to start of run state.
+   *
+   * @param numGenerations The maximum number of generations, which will cause the run to terminate
+   *     even if other criteria specified in the terminator are not currently met. Some selection
+   *     operators and replacement strategies may need to know the maximum number of generations to
+   *     operate properly, which is why this parameter is needed separately from other termination
+   *     criteria.
+   * @param terminator The termination strategy, such that the optimize method runs until that
+   *     strategy is satisfied.
+   * @return The current solution at the end of this run and its cost, which may or may not be the
+   *     best of run solution, and which may or may not be the same as the solution contained in
+   *     this metaheuristic's {@link org.cicirello.search.ProgressTracker ProgressTracker}, which
+   *     contains the best of all runs. Returns null if the run did not execute, such as if the
+   *     ProgressTracker already contains the theoretical best solution.
+   */
+  SolutionCostPair<T> optimize(int numGenerations, TerminationStrategy<T> terminator);
+
+  @Override
+  PopulationMetaheuristic<T> split();
+}

--- a/src/main/java/org/cicirello/search/evo/TerminationStrategy.java
+++ b/src/main/java/org/cicirello/search/evo/TerminationStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ *
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+/**
+ * This interface is used to define a termination strategy.
+ *
+ * @param <T> The type of object under optimization.
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
+ *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public interface TerminationStrategy<T> {
+
+  /**
+   * The state of the evolutionary algorithm prior to the start of a generation.
+   *
+   * @param <T> The type of object under optimization.
+   * @param numCompletedGenerations the number of completed generations
+   * @param fitnessEvaluations the total number of fitness evaluations so far for this call to
+   *     optimize
+   * @param bestSolution the best solution found across all generations so far for this run (i.e.,
+   *     for this call to optimize)
+   * @param bestFitness the fitness of the best solution found across all generations so far for
+   *     this run (i.e., for this call to optimize)
+   * @param currentPopulation the current population, enabling termination strategies that rely on
+   *     population-level statistics. This provides termination strategies with access to the actual
+   *     encodings of the members of the population as well as their fitnesses. Do not attempt to
+   *     mutate members of the population here, as the behavior of the EA may become unstable.
+   */
+  record ExecutionState<T>(
+      int numCompletedGenerations,
+      long fitnessEvaluations,
+      T bestSolution,
+      double bestFitness,
+      PopulationCandidates<T> currentPopulation) {}
+
+  /**
+   * Predicate method to determine whether or not to terminate the current run of the evolutionary
+   * algorithm.
+   *
+   * @param state the state of the evolutionary algorithm prior to the start of a generation
+   * @return true if and only if the evolutionary algorithm should terminate
+   */
+  boolean terminate(ExecutionState<T> state);
+}

--- a/src/test/java/org/cicirello/search/evo/TerminationStrategyTests.java
+++ b/src/test/java/org/cicirello/search/evo/TerminationStrategyTests.java
@@ -1,0 +1,115 @@
+/*
+ * Chips-n-Salsa: A library of parallel self-adaptive local search algorithms.
+ * Copyright (C) 2002-2026 Vincent A. Cicirello
+ *
+ * This file is part of Chips-n-Salsa (https://chips-n-salsa.cicirello.org/).
+ *
+ * Chips-n-Salsa is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chips-n-Salsa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.cicirello.search.evo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.cicirello.search.Configurator;
+import org.cicirello.search.ProgressTracker;
+import org.cicirello.search.SolutionCostPair;
+import org.cicirello.search.problems.OneMax;
+import org.cicirello.search.representations.BitVector;
+import org.junit.jupiter.api.*;
+
+/** JUnit test cases for TerminationStrategy interface. */
+public class TerminationStrategyTests {
+
+  @BeforeEach
+  public void seed() {
+    Configurator.configureRandomGenerator(42L);
+  }
+
+  @Test
+  public void testGenerationsCauseTermination() {
+    double M = 0.5;
+    int n = 10;
+    int L = 32;
+    OneMax problem = new OneMax();
+    ProgressTracker<BitVector> tracker = new ProgressTracker<BitVector>();
+    MutationOnlyGeneticAlgorithm ga =
+        new MutationOnlyGeneticAlgorithm(
+            n,
+            L,
+            new InverseCostFitnessFunction<BitVector>(problem),
+            M,
+            new FitnessProportionalSelection(),
+            tracker);
+    assertTrue(tracker == ga.getProgressTracker());
+    assertTrue(problem == ga.getProblem());
+    SolutionCostPair<BitVector> solution = ga.optimize(5, s -> s.numCompletedGenerations() >= 10);
+    // Make sure correct number of fitness evals
+    assertEquals(n * 6, ga.getTotalRunLength());
+    assertEquals(tracker.getCostDouble(), solution.getCostDouble());
+    BitVector b = solution.getSolution();
+    assertEquals(L, b.length());
+    assertEquals(L, tracker.getSolution().length());
+    assertEquals(b.countZeros(), solution.getCostDouble());
+  }
+
+  @Test
+  public void testTerminationStrategyCausesTermination() {
+    double M = 0.5;
+    int n = 10;
+    int L = 32;
+    OneMax problem = new OneMax();
+    ProgressTracker<BitVector> tracker = new ProgressTracker<BitVector>();
+    MutationOnlyGeneticAlgorithm ga =
+        new MutationOnlyGeneticAlgorithm(
+            n,
+            L,
+            new InverseCostFitnessFunction<BitVector>(problem),
+            M,
+            new FitnessProportionalSelection(),
+            tracker);
+    assertTrue(tracker == ga.getProgressTracker());
+    assertTrue(problem == ga.getProblem());
+    SolutionCostPair<BitVector> solution = ga.optimize(10, s -> s.numCompletedGenerations() >= 5);
+    // Make sure correct number of fitness evals
+    assertEquals(n * 6, ga.getTotalRunLength());
+    assertEquals(tracker.getCostDouble(), solution.getCostDouble());
+    BitVector b = solution.getSolution();
+    assertEquals(L, b.length());
+    assertEquals(L, tracker.getSolution().length());
+    assertEquals(b.countZeros(), solution.getCostDouble());
+  }
+
+  @Test
+  public void testAnotherThreadPausedEvolution() {
+    double M = 0.5;
+    int n = 10;
+    int L = 32;
+    OneMax problem = new OneMax();
+    ProgressTracker<BitVector> tracker = new ProgressTracker<BitVector>();
+    MutationOnlyGeneticAlgorithm ga =
+        new MutationOnlyGeneticAlgorithm(
+            n,
+            L,
+            new InverseCostFitnessFunction<BitVector>(problem),
+            M,
+            new FitnessProportionalSelection(),
+            tracker);
+    assertTrue(tracker == ga.getProgressTracker());
+    assertTrue(problem == ga.getProblem());
+    tracker.stop();
+    SolutionCostPair<BitVector> solution = ga.optimize(5, s -> s.numCompletedGenerations() >= 10);
+    assertNull(solution);
+  }
+}

--- a/src/test/java/org/cicirello/search/operators/reals/CauchyMutationTests.java
+++ b/src/test/java/org/cicirello/search/operators/reals/CauchyMutationTests.java
@@ -22,6 +22,7 @@ package org.cicirello.search.operators.reals;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.cicirello.search.Configurator;
 import org.cicirello.search.representations.RealValued;
 import org.cicirello.search.representations.RealVector;
 import org.junit.jupiter.api.*;
@@ -34,6 +35,11 @@ public class CauchyMutationTests extends SharedTestRealMutationOps {
 
   // precision used in floating-point comparisons
   private static final double EPSILON = 1e-10;
+
+  @BeforeEach
+  public void seed() {
+    Configurator.configureRandomGenerator(42L);
+  }
 
   @Test
   public void testToArray() {


### PR DESCRIPTION
## Summary
Added `TerminationStrategy` interface to enable specifying termination criteria other than maximum number of generations. Also, added a new `optimize(numberOfGenerations, TerminationStrategy)` method to all of the evolutionary algorithms that accepts an instance of an implementation of the new `TerminationStrategy` interface.

## Closing Issues
Closes #887 .

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
